### PR TITLE
I have added Client.ping and Client.selectDB methods

### DIFF
--- a/lib/mysql/client.js
+++ b/lib/mysql/client.js
@@ -117,8 +117,10 @@ Client.prototype.query = function(sql, params, cb) {
   return query;
 };
 
-
-Client.prototype.selectDB = function(db, cb) {
+/**
+* Functional equivalent to the SQL statement USE <database>.
+*/
+Client.prototype.use = function(db, cb) {
     var self = this;
 
     this._enqueue(function() {

--- a/test/system/test-client-use.js
+++ b/test/system/test-client-use.js
@@ -7,7 +7,8 @@ client.connect(gently.expect(function connectCb(err, result) {
 
     assert.strictEqual(result.affectedRows, 0);
   
-    client.selectDB('mysql', function() {   
+    //With callback
+    client.use('mysql', function() {   
         client.query('show tables', function(err, rows, fields) {
             //console.log('Showing tables from mysql database: ', rows.length);
             var name = '';
@@ -15,7 +16,7 @@ client.connect(gently.expect(function connectCb(err, result) {
                 name = i.replace('Tables_in_', '').toLowerCase();
             }
             assert.equal(name, 'mysql');
-            client.selectDB('information_schema', function() {
+            client.use('information_schema', function() {
                 client.query('show tables', function(err, rows, fields) {
                     //console.log('Show tables from information_schema: ', rows.length);
                     var name = '';
@@ -27,6 +28,17 @@ client.connect(gently.expect(function connectCb(err, result) {
                 });
             });
         });
+    });
+    
+    //Without callback
+    client.use('mysql');
+    client.query('show tables', function(err, rows, fields) {
+        //console.log('Showing tables from mysql database: ', rows.length);
+        var name = '';
+        for (var i in fields) {
+            name = i.replace('Tables_in_', '').toLowerCase();
+        }
+        assert.equal(name, 'mysql');
     });
 
 }));


### PR DESCRIPTION
Client.selectDB is pretty straight forward:

Client.selectDB('foo', function() {
     //You can query the 'foo' db now
});

Client.selectDB('bar', function() {
     //You can query the 'bar' db now
});

The Client.ping(); method is a little harder to deal with. Since the packet will never return from the write if the server is disconnected, I simple set a timeout and check to see if the OK has come back from the packet. If it has, everything is good. If it hasn't, then it will dequeue the ping and call Client.end(); Client.connect(); Then everything works as expected.

I have a test file, but in order to make the test runnable the interactive_timeout variable needs to be really low so the test doesn't take 2 days to complete ;) I have my current local machine set at 20 seconds. So my tests can run in a 5 sec interval to catch the disconnect and rerun it.

My thought was to add an autoPing config option, that when true it would call ping before each query (probably not good for performance). Or it could try to determine the interactive_timeout value (show variables like 'interactive_timeout'). Then we can drop a couple of seconds off of that value, set an interval that calls client.ping() and we should now have a solid connection.

Thoughts?
