### PR TITLE
Invalid handling of BLOB data fields in ROW_DATA_PACKET parser at query obj

### DIFF
--- a/lib/mysql/query.js
+++ b/lib/mysql/query.js
@@ -54,33 +54,31 @@ Query.prototype._handlePacket = function(packet) {
       }
       break;
     case Parser.ROW_DATA_PACKET:
-      var row = this._row = {}, field;
+      var row = this._row = {}, field, isBinary, binPtr;
 
       this._rowIndex = 0;
 
       packet.on('data', function(buffer, remaining) {
         if (!field) {
           field = self._fields[self._rowIndex];
-          row[field.name] = '';
+          isBinary = (field.fieldType === Query.FIELD_TYPE_BLOB ||
+                      field.fieldType === Query.FIELD_TYPE_TINY_BLOB ||
+                      field.fieldType === Query.FIELD_TYPE_MEDIUM_BLOB ||
+                      field.fieldType === Query.FIELD_TYPE_LONG_BLOB);
+          if (isBinary && buffer) {
+            binPtr = 0;
+            row[field.name] = new Buffer(buffer.length + remaining);
+          } else {
+            row[field.name] = '';
+          }
         }
 
         if (buffer) {
-          switch (field.fieldType) {
-            case Query.FIELD_TYPE_BLOB:
-            case Query.FIELD_TYPE_TINY_BLOB:
-            case Query.FIELD_TYPE_MEDIUM_BLOB:
-            case Query.FIELD_TYPE_LONG_BLOB:
-              if (row[field.name] == '') {
-                  row[field.name] = buffer; // Buffer
-              } else {
-                  var merge = new Buffer(row[field.name].length + buffer.length);
-                  row[field.name].copy(merge, 0, 0, row[field.name].length);
-                  buffer.copy(merge, row[field.name].length, 0, buffer.length);
-                  row[field.name] = merge;
-              }
-              break;
-            default:
-              row[field.name] += buffer.toString('utf-8');
+          if (isBinary) {
+            buffer.copy(row[field.name], binPtr, 0);
+            binPtr += buffer.length;
+          } else {
+            row[field.name] += buffer.toString('utf-8');
           }
         } else {
           row[field.name] = null;


### PR DESCRIPTION
Fixed invalid handling of BLOB data fields in ROW_DATA_PACKET parser
Binary data shouldn't be converted to utf-8 strs cause it breaks it down. As result converted blob to utf8 string can be of diff size and will contain invalid bytes sequences. 
Code tested on node.js 0.2.5 with data size 10k, 65k.
