### PR TITLE
Remove timezone shifting when getting dates from MySQL

### DIFF
--- a/lib/mysql/query.js
+++ b/lib/mysql/query.js
@@ -81,7 +81,7 @@ Query.prototype._handlePacket = function(packet) {
             case Query.FIELD_TYPE_DATE:
             case Query.FIELD_TYPE_DATETIME:
             case Query.FIELD_TYPE_NEWDATE:
-              row[field.name] = new Date(row[field.name]+'Z');
+              row[field.name] = new Date(row[field.name]);
               break;
             case Query.FIELD_TYPE_TINY:
             case Query.FIELD_TYPE_SHORT:


### PR DESCRIPTION
The extra 'Z' when parsing dates coming out of MySQL is to move the timezone of the date.  However, this causes the following problem: If you insert a date into the database based on (new Date()), then get it back out, it's now some number of hours away from what you get form another (new Date()).  That is, you can't count on the current date/time you put into the database 10 minutes ago to actually be "less than" the current date/time you get from Javascript right now.

The real solution is to just parse the date as-is from MySQL, but be sure to set the time zone in your node.js application appropriately: process.env.TZ = 'US/Eastern';
