### PR TITLE
Client.escape was throwing an error when dealing with objects

### DIFF
--- a/lib/mysql/client.js
+++ b/lib/mysql/client.js
@@ -178,6 +178,9 @@ Client.prototype.escape = function(val) {
   switch (typeof val) {
     case 'boolean': return (val) ? 'true' : 'false';
     case 'number': return val+'';
+    // don't just return a toString outright incase it returns
+    // characters we need to treat later
+    case 'object': val = val.toString(); break;
   }
 
   val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {

--- a/test/simple/test-client.js
+++ b/test/simple/test-client.js
@@ -365,6 +365,8 @@ test(function escape() {
   assert.equal(client.escape(false), 'false');
   assert.equal(client.escape(true), 'true');
   assert.equal(client.escape(5), '5');
+  assert.equal(client.escape({foo:'bar'}), "'[object Object]'");
+  assert.equal(client.escape([1,2,3]), "'1,2,3'");
 
   assert.equal(client.escape('Super'), "'Super'");
   assert.equal(client.escape('Sup\0er'), "'Sup\\0er'");


### PR DESCRIPTION
```
node.js:116
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: Object #<Object> has no method 'replace'
    at Client.escape (/home/nick/code/node/node-mysql/lib/mysql/client.js:183:13)
```

This was due to the Client.escape method not catching vars with typeof == object. Admittedly they shouldn't be being passed to a mysql query but they need to be handled gracefully.

Pull request calls a toString() inside escape where typeof == object and then continues as normal in case toString() introduces any bad characters.
