### PR TITLE
Don't alter the args array that is being passed into query()

### DIFF
--- a/lib/mysql/client.js
+++ b/lib/mysql/client.js
@@ -154,16 +154,16 @@ Client.prototype.write = function(packet) {
 };
 
 Client.prototype.format = function(sql, params) {
-  var escape = this.escape;
+  var escape = this.escape, i = 0;
   sql = sql.replace(/\?/g, function() {
-    if (params.length == 0) {
+    if (params.length === i) {
       throw new Error('too few parameters given');
     }
 
-    return escape(params.shift());
+    return escape(params[i++]);
   });
 
-  if (params.length) {
+  if (params.length > i) {
     throw new Error('too many parameters given');
   }
 

--- a/test/system/test-client-query.js
+++ b/test/system/test-client-query.js
@@ -33,10 +33,24 @@ client.query(
   })
 );
 
+var args = ['super cool', 'this is a nice long text', '2010-08-16 10:00:23'];
+
 client.query(
   'INSERT INTO '+TEST_TABLE+' '+
   'SET title = ?, text = ?, created = ?',
-  ['super cool', 'this is a nice long text', '2010-08-16 10:00:23'],
+  args,
+  gently.expect(function insertCb(err) {
+    if (err) {
+      throw err;
+    }
+  })
+);
+
+// Insert a second time.
+client.query(
+  'INSERT INTO '+TEST_TABLE+' '+
+  'SET title = ?, text = ?, created = ?',
+  args,
   gently.expect(function insertCb(err) {
     if (err) {
       throw err;
@@ -60,11 +74,11 @@ var query = client.query(
       throw err;
     }
 
-    assert.equal(results.length, 2);
-    assert.equal(results[1].title, 'another entry');
-    assert.ok(typeof results[1].id == 'number');
+    assert.equal(results.length, 3);
+    assert.equal(results[2].title, 'another entry');
+    assert.ok(typeof results[2].id == 'number');
     assert.ok(results[0].created instanceof Date);
-    assert.strictEqual(results[1].created, null);
+    assert.strictEqual(results[2].created, null);
     client.end();
   })
 );


### PR DESCRIPTION
When passing a placeholder array, `node-mysql` completely empties that array. This means that the same array can't be used twice for running similar queries.
