### PR TITLE
> 2x performance increase on selects with change to buffer slicing

### DIFF
--- a/lib/mysql/parser.js
+++ b/lib/mysql/parser.js
@@ -23,6 +23,12 @@ function Parser() {
 util.inherits(Parser, EventEmitter);
 module.exports = Parser;
 
+function BufferSlice(buffer, start, end){
+    this.toString = function(encoding){
+        return buffer.toString(encoding, start, end);
+    }
+}
+
 Parser.prototype.write = function(buffer) {
   var i = 0,
       c = null,
@@ -553,12 +559,12 @@ Parser.prototype.write = function(buffer) {
         if (i + remaining > buffer.length) {
           read = buffer.length - i;
           packet.index += read;
-          packet.emit('data', buffer.slice(i, buffer.length), remaining - read);
+          packet.emit('data', new BufferSlice(buffer, i, buffer.length), remaining - read);
           // the -1 offsets are because these values are also manipulated by the loop itself
           packet.received += read - 1;
           i = buffer.length;
         } else {
-          packet.emit('data', buffer.slice(i, i + remaining), 0);
+          packet.emit('data', new BufferSlice(buffer, i, i + remaining), 0);
           i += remaining - 1;
           packet.received += remaining - 1;
           advance(Parser.COLUMN_VALUE_LENGTH);


### PR DESCRIPTION
Seems that:

<pre>buffer.toString(encoding, start, end)</pre>

is considerably faster than:

<pre>buffer.slice(start, end).toString(encoding)</pre>

So making that small change speeds up selects by > 2 times in my tests.
