### PR TITLE
Handle insertion of Date objects into database

### DIFF
--- a/lib/mysql/client.js
+++ b/lib/mysql/client.js
@@ -181,7 +181,11 @@ Client.prototype.escape = function(val) {
   }
 
   if (typeof val === 'object') {
-    val = val.toString();
+    if (typeof val.toISOString === 'function') {
+      val = val.toISOString();
+    } else {
+      val = val.toString();
+    }
   }
 
   val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {

--- a/test/simple/test-client.js
+++ b/test/simple/test-client.js
@@ -366,6 +366,7 @@ test(function escape() {
   assert.equal(client.escape(5), '5');
   assert.equal(client.escape({foo:'bar'}), "'[object Object]'");
   assert.equal(client.escape([1,2,3]), "'1,2,3'");
+  assert.equal(client.escape(new Date(Date.UTC(2011,6,6,6,6,6,6))), "'2011-07-06T06:06:06.006Z'");
 
   assert.equal(client.escape('Super'), "'Super'");
   assert.equal(client.escape('Sup\0er'), "'Sup\\0er'");


### PR DESCRIPTION
The naive approach of calling toString on any object to insert it into the database unfortunately doesn't work with Date objects. 

Dates have a toISOString method, which is suitable for this case - the patch simply does a duck-typed check for this method and uses it.
