### PR TITLE
Better array parameter handling.

### DIFF
--- a/lib/mysql/client.js
+++ b/lib/mysql/client.js
@@ -171,6 +171,8 @@ Client.prototype.format = function(sql, params) {
 };
 
 Client.prototype.escape = function(val) {
+	var escape = this.escape;
+
   if (val === undefined || val === null) {
     return 'NULL';
   }
@@ -181,7 +183,9 @@ Client.prototype.escape = function(val) {
   }
 
 	if ( val instanceof Array ) {
-		return "'" + val.join( "','" ) + "'";
+		var sanitized = val.map( function( v ) { return escape( v ); } );
+
+		return "'" + sanitized.join( "','" ) + "'";
 	}
 
   if (typeof val === 'object') {


### PR DESCRIPTION
When using an array as an escaped query parameter, format it as a list of elements rather than a single serialized string. This makes their behavior much more intuitive in e.g. WHERE IN clauses.
