### PR TITLE
Joined Queries Fix

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -59,13 +59,16 @@ Query.prototype._handlePacket = function(packet) {
       packet.on('data', function(buffer, remaining) {
         if (!field) {
           field = self._fields[self._rowIndex];
-          row[field.name] = '';
+          if (self.addNamespace(row,field)){
+            row[field.table] = {}; 
+          }
+          row[field.table][field.name] = '';
         }
 
         if (buffer) {
-          row[field.name] += buffer.toString('utf-8');
+          row[field.table][field.name] += buffer.toString('utf-8');
         } else {
-          row[field.name] = null;
+          row[field.table][field.name] = null;
         }
 
         if (remaining !== 0) {
@@ -79,7 +82,7 @@ Query.prototype._handlePacket = function(packet) {
             case Query.FIELD_TYPE_DATE:
             case Query.FIELD_TYPE_DATETIME:
             case Query.FIELD_TYPE_NEWDATE:
-              row[field.name] = new Date(row[field.name]);
+              row[field.table][field.name] = new Date(row[field.table][field.name]);
               break;
             case Query.FIELD_TYPE_TINY:
             case Query.FIELD_TYPE_SHORT:
@@ -87,13 +90,13 @@ Query.prototype._handlePacket = function(packet) {
             case Query.FIELD_TYPE_LONGLONG:
             case Query.FIELD_TYPE_INT24:
             case Query.FIELD_TYPE_YEAR:
-              row[field.name] = parseInt(row[field.name], 10);
+              row[field.table][field.name] = parseInt(row[field.table][field.name], 10);
               break;
             case Query.FIELD_TYPE_DECIMAL:
             case Query.FIELD_TYPE_FLOAT:
             case Query.FIELD_TYPE_DOUBLE:
             case Query.FIELD_TYPE_NEWDECIMAL:
-              row[field.name] = parseFloat(row[field.name]);
+              row[field.table][field.name] = parseFloat(row[field.table][field.name]);
               break;
           }
         }
@@ -101,7 +104,7 @@ Query.prototype._handlePacket = function(packet) {
         if (self._rowIndex == self._fields.length) {
            delete self._row;
            delete self._rowIndex;
-           self.emit('row', row);
+           self.emit('row', self.mergeRows(row));
            return;
         }
 
@@ -109,6 +112,63 @@ Query.prototype._handlePacket = function(packet) {
       });
       break;
   }
+};
+
+Query.prototype.mergeRows = function mergeRows(namespacedRow){
+  // This function transforms the row into a compatible structure
+  // that won't break existing code, but allows for joins without
+  // overwriting keys.  EG
+  // 'select * from foo f, bar b' would yield:
+  //  {f:{field1:1,field2:2},
+  //   b:{field1:1,field2:2}}
+  // this function takes that and turns it to:
+  //  {field1:1,field2:2,
+  //   b:{field1:1,field2:2}}
+  // NB, the "first" table namespace in the select will be removed and all
+  // remaining namespaces will become a child key.  You can then
+  // access them in a sane/easy way: row.field1, row.b.field1, etc.
+  if (!(namespacedRow instanceof Array)){
+    // darn JS. i wish forEach worked on objects and not just arrays
+    namespacedRow = [namespacedRow];
+  }
+  var mergedRows = [];
+  namespacedRow.forEach(function(row){
+    // this could probably use some refactoring/revision
+    var firstLoop = true;
+    var firstTable = '';
+    var remainingTables = [];
+    for (var table in row){
+      if (firstLoop){
+        firstLoop = false;
+        firstTable = table;
+      } else {
+        remainingTables.push(table);
+      }
+    }
+    mergedRow = row[firstTable];
+    remainingTables.forEach(function(table){
+      mergedRow[table] = row[table];
+    });
+  });
+  // should probably emit something, but for now, simple return.
+  //console.log('calling back from mergeRows');
+  //self.emit('mergedRows',mergedRows);
+  return mergedRow;
+};
+
+Query.prototype.addNamespace = function addNamespace(row,field){
+  // simple function to determine if we need to
+  // add a table namespace.
+  // 'select * from foo f, bar b' would yield:
+  //  {f:{field1:1,field2:2},
+  //   b:{field1:1,field2:2}}
+  // EG, each table namespace is a key.
+  if(!row[field.table]){
+    return true;
+  } else {
+    return false;
+  }
+  
 };
 
 Query.FIELD_TYPE_DECIMAL     = 0x00;


### PR DESCRIPTION
This is in reference to https://github.com/felixge/node-mysql/pull/45

robinduckett submitted a patch that would break existing implementations that use node-mysql.  The patch that I'm proposing will not break existing code.  It will continue to return rows in the same manner for single table queries, but when using it with a join, it will expand that row, keeping namespaces when appropriate.  I've been using this new code for about a week now without problems, but bugs could still exist.  It could probably use some refactoring as well, but the general idea, I think works.  Check it out :)

  // 'select \* from foo f, bar b' would yield:
  //  {f:{field1:1,field2:2},
  //   b:{field1:1,field2:2}}
  // Eventually, it ends up as:
  //  {field1:1,field2:2,
  //   b:{field1:1,field2:2}}
  // NB, the "first" table namespace in the select will be removed and all
  // remaining namespaces will become a child key.  You can then
  // access them in a sane/easy way: row.field1, row.b.field1, etc.
