### PR TITLE
Fixed: Client.escape does not escape NaN properly

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -166,7 +166,7 @@ Client.prototype.escape = function(val) {
     return 'NULL';
   }
 
-  if (typeof val === 'object' || (typeof val === 'number') && (isNaN(val) || !isFinite(val))) {
+  if (typeof val === 'object' || (typeof val === 'number' && (isNaN(val) || !isFinite(val)))) {
     val = (typeof val.toISOString === 'function')
       ? val.toISOString()
       : val.toString();


### PR DESCRIPTION
example without fix:

var c = require('mysql').createClient();
var sql = 'SELECT \* FROM Foo WHERE Bar='+c.escape(NaN);
// sql == 'SELECT \* FROM Foo WHERE Bar=NaN'

with this fix Client.escape escapes NaN to an empty string:

var c = require('mysql').createClient();
var sql = 'SELECT \* FROM Foo WHERE Bar='+c.escape(NaN);
// sql == 'SELECT \* FROM Foo WHERE Bar=""'

edit: obviously this is a contrived example, you wouldn't normally be using Client.escape manually, but the same applies with prepared statements eg:

mysql.query('SELECT \* FROM Foo WHERE Bar=?', [parseInt(someNaNValue,10)], myCallback);
// execs SELECT \* FROM Foo WHERE Bar=NaN
