### PR TITLE
Fix for #118 - change #format() to not replace "?" in query string literals

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -146,7 +146,29 @@ Client.prototype.format = function(sql, params) {
   var escape = this.escape;
   params = params.concat();
 
-  sql = sql.replace(/\?/g, function() {
+  // regex looks for placeholder(?) or unescaped quotes('). 
+  // Unescaped quotes are those which are preceded by:
+  //    * beginning of the line 
+  //    * or non-escape char (not \)
+  //    * or even number of escape chars (\\)
+  var regex = /((^|[^\\])(\\\\)*')|\?/g;
+  var inLiteral = false;
+  sql = sql.replace(regex, function(str) {
+    
+	// if it's not placeholder, it must be an unescaped quote
+	if (str !== '?') {
+	  // switch state
+	  inLiteral = !inLiteral;
+	  
+	  // put it back
+	  return str;
+	}
+	
+	// if placeholder found in literal
+	if (inLiteral)
+		// dont touch
+		return str;
+	
     if (params.length == 0) {
       throw new Error('too few parameters given');
     }

--- a/test/fast/test-client.js
+++ b/test/fast/test-client.js
@@ -31,3 +31,31 @@ test('Timeout reconnect works with empty queue', function() {
   // This must not throw an error
   client._handlePacket(packet);
 });
+
+test('#format() does not substitute ? in string literals', function() {
+  
+  // various positions
+  // ? '?' ? => 1 '?' 2
+  var sql = '? \'? \' ?';		// input
+  var exp = '1 \'? \' 2';		// expected output
+  var params = [1, 2];			// params
+  
+  assert.strictEqual(exp, client.format(sql, params));
+  
+  // trivial test: 
+  // '?' => '?' 
+  sql = '\'?\'';
+  exp = '\'?\'';
+  params = [];
+  
+  assert.strictEqual(exp, client.format(sql, params));
+  
+  // escaped quote:
+  // '? \' ?' ? => '? \' ?' 1
+  sql = '\'? \\\' ?\' ?';
+  exp = '\'? \\\' ?\' 1';
+  params = [1];
+  
+  assert.strictEqual(exp, client.format(sql, params));
+  
+});


### PR DESCRIPTION
Fixes #118

https://github.com/felixge/node-mysql/issues/118

Option 2
Modified Client.prototype.format to not replace "?" in query string literals
