### PR TITLE
return BLOB columns as Buffers instead of strings

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -53,23 +53,42 @@ Query.prototype._handlePacket = function(packet) {
       break;
     case Parser.ROW_DATA_PACKET:
       var row = this._row = {}, field;
+      var cellBuffer, totalBytesRead;
 
       this._rowIndex = 0;
 
       packet.on('data', function(buffer, remaining) {
         if (!field) {
           field = self._fields[self._rowIndex];
-          row[field.name] = '';
+          row[field.name] = cellBuffer = new Buffer(buffer.length + remaining);
+          totalBytesRead = 0;
         }
 
         if (buffer) {
-          row[field.name] += buffer.toString('utf-8');
+          //if((totalBytesRead + buffer.length) > cellBuffer.length) {
+          //  throw new Error("we received more bytes than was promised.  (this shouldn't happen)");
+          //}
+          buffer.copy(cellBuffer, totalBytesRead);
+          totalBytesRead += buffer.length;
         } else {
           row[field.name] = null;
         }
 
         if (remaining !== 0) {
           return;
+        }
+
+        //all the data is collected...  convert to string if it's not a blob
+        if(buffer) {
+          switch (field.fieldType) {
+            case Query.FIELD_TYPE_TINY_BLOB:
+            case Query.FIELD_TYPE_MEDIUM_BLOB:
+            case Query.FIELD_TYPE_LONG_BLOB:
+            case Query.FIELD_TYPE_BLOB:
+              break;
+            default:
+              row[field.name] = row[field.name].toString('utf-8');
+          }
         }
 
         self._rowIndex++;


### PR DESCRIPTION
I wrote this before I saw that there is an existing pull request for the same feature.

I'm leaving it anyway in case you like this impl better.

There is room for at least 1 micro-optimization:  we could use the passed-in buffer (rather than making a copy) if the entire ROW_DATA_PACKET comes through as 1 buffer
