### PR TITLE
return BLOB columns as Buffers instead of strings

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -16,6 +16,48 @@ function Query(properties) {
 util.inherits(Query, EventEmitter);
 module.exports = Query;
 
+function doTypeCast(text, fieldType) {
+  switch (fieldType) {
+    case Query.FIELD_TYPE_TIMESTAMP:
+    case Query.FIELD_TYPE_DATE:
+    case Query.FIELD_TYPE_DATETIME:
+    case Query.FIELD_TYPE_NEWDATE:
+      return new Date(text);
+    case Query.FIELD_TYPE_TINY:
+    case Query.FIELD_TYPE_SHORT:
+    case Query.FIELD_TYPE_LONG:
+    case Query.FIELD_TYPE_LONGLONG:
+    case Query.FIELD_TYPE_INT24:
+    case Query.FIELD_TYPE_YEAR:
+      return parseInt(text, 10);
+    case Query.FIELD_TYPE_FLOAT:
+    case Query.FIELD_TYPE_DOUBLE:
+      // decimal types cannot be parsed as floats because
+      // V8 Numbers have less precision than some MySQL Decimals
+      return parseFloat(text);
+  }
+  return text;
+}
+
+function coalesceBuffers(buffers) {
+  var totalSize = 0;
+  for(var i=0, c=buffers.length; i<c; i++) {
+    totalSize += buffers[i].length;
+  }
+  var bigBuffer = new Buffer(totalSize);
+  for(var i=0, c=buffers.length, curOffset=0; i<c; i++) {
+    buffers[i].copy(bigBuffer, curOffset);
+    curOffset += buffers[i].length;
+  }
+  return bigBuffer;
+}
+
+function fieldShouldBeReturnedAsBuffer(field) {
+  var blob_or_text = 0 != (field.flags & Query.BLOB_FLAG);
+  var binary = 0 != (field.flags & Query.BINARY_FLAG);
+  return blob_or_text && binary;
+}
+
 Query.prototype._handlePacket = function(packet) {
   var self = this;
 
@@ -52,60 +94,49 @@ Query.prototype._handlePacket = function(packet) {
       }
       break;
     case Parser.ROW_DATA_PACKET:
-      var row = this._row = {}, field;
+      var row = {};
 
-      this._rowIndex = 0;
+      var rowIndex = 0;
+      var cellBuffers = null;
+
+      function finishCell() {
+        var field = self._fields[rowIndex];
+        if(!cellBuffers) {
+          row[field.name] = null;
+        } else {
+          //coalesce collected buffers
+          var cell = coalesceBuffers(cellBuffers);
+
+          if(!fieldShouldBeReturnedAsBuffer(field)) {
+            //if it's not a BLOB, convert to string and perhaps typecast
+            cell = cell.toString('utf-8');
+            if(self.typeCast) {
+              cell = doTypeCast(cell, field.fieldType);
+            }
+          }
+          row[field.name] = cell;
+        }
+
+        //prepare for next field
+        ++rowIndex;
+        cellBuffers = null;
+        if (rowIndex == self._fields.length) {
+           self.emit('row', row);
+        }
+      }
 
       packet.on('data', function(buffer, remaining) {
-        if (!field) {
-          field = self._fields[self._rowIndex];
-          row[field.name] = '';
-        }
-
         if (buffer) {
-          row[field.name] += buffer.toString('utf-8');
-        } else {
-          row[field.name] = null;
-        }
-
-        if (remaining !== 0) {
-          return;
-        }
-
-        self._rowIndex++;
-        if (self.typeCast && buffer !== null) {
-          switch (field.fieldType) {
-            case Query.FIELD_TYPE_TIMESTAMP:
-            case Query.FIELD_TYPE_DATE:
-            case Query.FIELD_TYPE_DATETIME:
-            case Query.FIELD_TYPE_NEWDATE:
-              row[field.name] = new Date(row[field.name]);
-              break;
-            case Query.FIELD_TYPE_TINY:
-            case Query.FIELD_TYPE_SHORT:
-            case Query.FIELD_TYPE_LONG:
-            case Query.FIELD_TYPE_LONGLONG:
-            case Query.FIELD_TYPE_INT24:
-            case Query.FIELD_TYPE_YEAR:
-              row[field.name] = parseInt(row[field.name], 10);
-              break;
-            case Query.FIELD_TYPE_FLOAT:
-            case Query.FIELD_TYPE_DOUBLE:
-              // decimal types cannot be parsed as floats because
-              // V8 Numbers have less precision than some MySQL Decimals
-              row[field.name] = parseFloat(row[field.name]);
-              break;
+          cellBuffers = cellBuffers || [];
+          cellBuffers.push(buffer);
+          if(remaining === 0) {
+            finishCell();
           }
+        } else {
+          cellBuffers = null;
+          finishCell();
         }
 
-        if (self._rowIndex == self._fields.length) {
-           delete self._row;
-           delete self._rowIndex;
-           self.emit('row', row);
-           return;
-        }
-
-        field = null;
       });
       break;
   }
@@ -138,3 +169,17 @@ Query.FIELD_TYPE_BLOB        = 0xfc;
 Query.FIELD_TYPE_VAR_STRING  = 0xfd;
 Query.FIELD_TYPE_STRING      = 0xfe;
 Query.FIELD_TYPE_GEOMETRY    = 0xff;
+
+Query.NOT_NULL_FLAG          = 0x0001;
+Query.PRI_KEY_FLAG           = 0x0002;
+Query.UNIQUE_KEY_FLAG        = 0x0004;
+Query.MULTIPLE_KEY_FLAG      = 0x0008;
+Query.BLOB_FLAG              = 0x0010;
+Query.UNSIGNED_FLAG          = 0x0020;
+Query.ZEROFILL_FLAG          = 0x0040;
+Query.BINARY_FLAG            = 0x0080;
+Query.ENUM_FLAG              = 0x0100;
+Query.AUTO_INCREMENT_FLAG    = 0x0200;
+Query.TIMESTAMP_FLAG         = 0x0400;
+Query.SET_FLAG               = 0x0800;
+

--- a/test/slow/test-client-query.js
+++ b/test/slow/test-client-query.js
@@ -65,6 +65,33 @@ test('Long fields', function(done) {
   test(true);
 });
 
+test('BLOB fields returned as Buffers', function(done) {
+  this.client.query('USE '+common.TEST_DB, function useDbCb(err) {
+    if (err) done(err);
+  });
+  this.client.query(
+    'CREATE TEMPORARY TABLE '+common.TEST_TABLE+
+    '(mytext TEXT, myblob BLOB)',
+    function createTableCb(err) {
+      if (err) done (err);
+    }
+  );
+  this.client.query(
+    'INSERT INTO '+common.TEST_TABLE+' '+
+    'SET mytext = ?, myblob = ?',
+    ['asdf', 'asdf']
+  );
+  this.client.query(
+    'SELECT * FROM '+common.TEST_TABLE,
+    function selectCb(err, results, fields) {
+      if (err) done (err);
+      assert.strictEqual(results[0].mytext, 'asdf');
+      assert.strictEqual(typeof results[0].myblob, 'object');
+      assert.strictEqual(results[0].myblob.toString('utf-8'), 'asdf');
+    }
+  );
+});
+
 test('Query a NULL value', function(done) {
   this.client.query('SELECT NULL as field_a, NULL as field_b', function(err, results) {
     assert.strictEqual(results[0].field_a, null);


### PR DESCRIPTION
You rejected my previous request because I didn't add a test.

So now, I'm back, with a test :)

You were quite right to reject my previous patch, and I would have added a test previously if I had realized there was a test suite.  Mea culpa.

My previous patch failed some of the already existing tests, even.

This new patch is a little more 'intrusive' to the code.  I reshaped the way the ROW_PACKET_DATA buffers are handled.  But, everything works for me locally, the tests now pass, and I added a new test to cover the BLOB functionality.
