### PR TITLE
Remove .gitignore from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
This allows projects to include their dependencies into their repository
if they choose, and not have it ignore the nested dependencies

Could possibly remove benchmark/ and tool/ as well?
