### PR TITLE
fix: multibyte chars broken when read multiple 'raw data packet'

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -52,7 +52,7 @@ Query.prototype._handlePacket = function(packet) {
       }
       break;
     case Parser.ROW_DATA_PACKET:
-      var row = this._row = {}, field;
+      var row = this._row = {}, buffers = {}, field;
 
       this._rowIndex = 0;
 
@@ -60,10 +60,17 @@ Query.prototype._handlePacket = function(packet) {
         if (!field) {
           field = self._fields[self._rowIndex];
           row[field.name] = '';
+          buffers[field.name] = new Buffer(0);
         }
 
         if (buffer) {
-          row[field.name] += buffer.toString('utf-8');
+          var oldBuf = buffers[field.name];
+          var newBuf = new Buffer(oldBuf.length + buffer.length);
+          oldBuf.copy(newBuf, 0, 0, oldBuf.length);
+          buffer.copy(newBuf, oldBuf.length, 0, buffer.length);
+
+          buffers[field.name] = newBuf;
+          row[field.name] = newBuf.toString('utf8');
         } else {
           row[field.name] = null;
         }


### PR DESCRIPTION
original code(lib/query.js)

``` js
Query.prototype._handlePacket = function(packet) {
  ...
  if (buffer) {
    row[field.name] += buffer.toString('utf-8');
  }
  ...
}
```

it will be broken string in incoming multibyte<toString('utf8')>.

new approach below.

``` js
Query.prototype._handlePacket = function(packet) {
  ...
  buffers[field.name] = new Buffer(0);
  ...
  if (buffer) {
    var oldBuf = buffers[field.name];
    var newBuf = new Buffer(oldBuf.length + buffer.length);
    oldBuf.copy(newBuf, 0, 0, oldBuf.length);
    buffer.copy(newBuf, oldBuf.length, 0, buffer.length);

    buffers[field.name] = newBuf;
    row[field.name] = newBuf.toString('utf8'); // toString is used by read-all buffer(s).
  }
  ...
}
```

it will be right string in multibyte.
