### PR TITLE
Add Client.queryWithEvents() (refactor branch)

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -162,7 +162,7 @@ Client.prototype.query = function(sql, params, cb) {
     }
   });
   emitter.on('error', function(err) { cb(err); });
-  return this.queryWithEvents(sql, params, emitter);
+  return this.queryWithEvents(sql, emitter);
 };
 
 Client.prototype.write = function(packet) {


### PR DESCRIPTION
(This is the same as https://github.com/felixge/node-mysql/pull/164, but ported to the refactor branch).

queryWithEvents() behaves just like query(), but it accepts an EventEmitter instead of a callback. This allows retrieved rows to be passed back to the user one at a time, allowing memory-efficient processing of large result sets.

e.g.

var client = mysql.createClient();

var emitter = new EventEmitter();
emitter.on("row", function(row) { console.log(util.inspect(row)); });
emitter.on("end", function(result) { client.end(); });

client.queryWithEvents("SELECT \* FROM table_with_millions_of_rows", emitter);
