### PR TITLE
removed LONG and LONGLONG from mysql number formats parsed into ints

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -83,10 +83,9 @@ Query.prototype._handlePacket = function(packet) {
               break;
             case Query.FIELD_TYPE_TINY:
             case Query.FIELD_TYPE_SHORT:
-            case Query.FIELD_TYPE_LONG:
-            case Query.FIELD_TYPE_LONGLONG:
             case Query.FIELD_TYPE_INT24:
             case Query.FIELD_TYPE_YEAR:
+              // long/bigint types cannot be parsed as V8 numbers not represent them properly
               row[field.name] = parseInt(row[field.name], 10);
               break;
             case Query.FIELD_TYPE_FLOAT:


### PR DESCRIPTION
Since long/bigint, etc. cannot be properly represented in V8 (i.e. the number is rounded), I suggest not trying to parse them into an int, but let them pass through as strings so the user can decided how to handle the number.

This should resolve https://github.com/felixge/node-mysql/issues/145
