### PR TITLE
Quickfix for fieldname encoding #138

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -36,7 +36,7 @@ Query.prototype._handlePacket = function(packet) {
       if (!this._fields) {
         this._fields = [];
       }
-
+      packet.name = (new Buffer(packet.name, 'ascii')).toString('utf8')
       this._fields.push(packet);
       this.emit('field', packet);
       break;


### PR DESCRIPTION
Hi

I needed to have my fieldnames in utf-8. This is just a simple fix for #138
