### PR TITLE
Escaping array of strings with spaces is broken

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -143,7 +143,7 @@ Client.prototype.write = function(packet) {
 };
 
 Client.prototype.format = function(sql, params) {
-  var escape = this.escape;
+  var self = this;
   params = params.concat();
 
   sql = sql.replace(/\?/g, function() {
@@ -151,7 +151,7 @@ Client.prototype.format = function(sql, params) {
       throw new Error('too few parameters given');
     }
 
-    return escape(params.shift());
+    return self.escape(params.shift());
   });
 
   if (params.length) {
@@ -162,8 +162,7 @@ Client.prototype.format = function(sql, params) {
 };
 
 Client.prototype.escape = function(val) {
-  var escape = this.escape;
-
+  var self = this;
   if (val === undefined || val === null) {
     return 'NULL';
   }
@@ -174,7 +173,7 @@ Client.prototype.escape = function(val) {
   }
 
   if (Array.isArray(val)) {
-    var sanitized = val.map( function( v ) { return escape( v ); } );
+    var sanitized = val.map( function( v ) { return self.escape( v ); } );
     return sanitized.join( "," );
   }
 

--- a/test/unit/legacy/test-client.js
+++ b/test/unit/legacy/test-client.js
@@ -32,6 +32,8 @@ test(function format() {
   assert.throws(function() {
     var sql = client.format('? + ? = ?', [1, 2, 3, 4]);
   });
+
+  assert.equal(client.format('(?)', [['foo bar']]), "('foo bar')");
 });
 
 test(function escape() {


### PR DESCRIPTION
```
client.query("SELECT * FROM foo WHERE bar IN (?)", [["foo bar"]], ...)
```

doesn't work as expected
