### PR TITLE
Added a new function called escape_str

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -146,6 +146,10 @@ Returns some server statistics provided by MySql.
 Allows to safely insert a list of `params` into a `sql` string using the
 placeholder mechanism described above.
 
+### client.escape_str(val)
+
+Escapes a single `val` for use inside of a sql string without single quotations.
+
 ### client.escape(val)
 
 Escapes a single `val` for use inside of a sql string.

--- a/lib/client.js
+++ b/lib/client.js
@@ -162,6 +162,11 @@ Client.prototype.format = function(sql, params) {
 };
 
 Client.prototype.escape = function(val) {
+	var escape_str = this.escape_str;
+	return "'"+escape_str(val)+"'";
+};
+
+Client.prototype.escape_str = function(val) {
   var escape = this.escape;
 
   if (val === undefined || val === null) {
@@ -195,7 +200,7 @@ Client.prototype.escape = function(val) {
       default: return "\\"+s;
     }
   });
-  return "'"+val+"'";
+  return val;
 };
 
 Client.prototype.ping = function(cb) {


### PR DESCRIPTION
Added a new function called escape_str to escape a `val` without adding single quotations at the end.
