### PR TITLE
Pass localtime to mysql instead of iso time

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -180,7 +180,7 @@ Client.prototype.escape = function(val) {
 
   if (typeof val === 'object') {
     val = (typeof val.toISOString === 'function')
-      ? val.toISOString()
+      ? this._dateToDbString(val)
       : val.toString();
   }
 
@@ -442,6 +442,18 @@ Client.prototype._sendOldAuth = function(greeting) {
 
   this.write(packet);
 };
+
+Client.prototype._dateToDbString = function(d) {
+  function pad2(n) { return n < 10 ? '0' + n : n; };
+  function pad3(n) { return n < 10 ? '00' + n : n < 100 ? '0' + n : n; };
+  return d.getFullYear() + '-'
+      + pad2(d.getMonth() + 1) + '-'
+      + pad2(d.getDate()) + ' '
+      + pad2(d.getHours()) + ':'
+      + pad2(d.getMinutes()) + ':'
+      + pad2(d.getSeconds()) + '.'
+      + pad3(d.getMilliseconds());
+}
 
 Client.defaultFlags =
     constants.CLIENT_LONG_PASSWORD

--- a/test/unit/legacy/test-client.js
+++ b/test/unit/legacy/test-client.js
@@ -42,7 +42,7 @@ test(function escape() {
   assert.equal(client.escape(5), '5');
   assert.equal(client.escape({foo:'bar'}), "'[object Object]'");
   assert.equal(client.escape([1,2,3]), "'1','2','3'");
-  assert.equal(client.escape(new Date(Date.UTC(2011,6,6,6,6,6,6))), "'2011-07-06T06:06:06.006Z'");
+  assert.equal(client.escape(new Date(2011,6,7,8,9,10,11)), "'2011-07-07 08:09:10.011'");
 
   assert.equal(client.escape('Super'), "'Super'");
   assert.equal(client.escape('Sup\0er'), "'Sup\\0er'");


### PR DESCRIPTION
When reading dates, the Date constructor is used, which expects localtime. Also mysql timestamp data-type expects localtime for input/output.

From another viewpoint, if prior the patch, you insert a date (in a timestamp _or_ datetime object) and then read it back, you get it offset by the local timezone. If you apply the batch both timestamp and datetime objects are read/written properly.

Even this fix isn't perfect. It won't work properly if mysql timezone differs from node's timezone. Maybe a function can be added in the client "syncTz" which reads the mysql timezone (select @@session.time_zone) and if it isn't SYSTEM, it calculates the offset and then serializes dates for the servers TZ.
