### PR TITLE
Added connection pool for v2.0 and tests. 

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -1,0 +1,219 @@
+var EventEmitter  = require('events').EventEmitter;
+var Util          = require('util');
+var Connection    = require('./Connection');
+
+module.exports = Pool;
+Util.inherits(Pool, EventEmitter);
+
+function Pool(mysqlOptions,poolOptions) {
+  EventEmitter.call(this);
+  
+  this.connections        = [];
+  this.allocRequests = [];
+  this.options       = { poolSize: 10,
+                         endOnRelease: false,
+                         resetSessionOnRelease: false, 
+                       };
+  poolOptions = poolOptions || {};
+  for (var prop in poolOptions){
+    this.options[prop] = poolOptions[prop];
+  }
+  
+  if ('function' === typeof this.options.createConnection) {
+    this._createConnection = this.options.createConnection;
+  } else {
+    this._createConnection  = function() { 
+      return new Connection( {config: mysqlOptions});
+    }
+  }
+}
+var idCounter = 0;
+Pool.prototype.createConnection = function(cb) {
+  var self        = this;
+  if (this.connections.length < this.options.poolSize) {
+    var conn        = this._createConnection();
+    conn.id         = idCounter++;
+    conn.allocated  = true;    
+    
+    this._addEventListeners(conn);
+    this.connections.push(conn);
+    
+    conn.connect( function(err) {
+      if (err) {
+        self._doCallback(cb,[err,false]);
+      } else {
+        self._doCallback(cb,[false,conn]);
+      }
+    });    
+  } else {
+    var err   = new Error("Cannot add to pool; pool at size configured.");
+    err.fatal = false;
+    err.code  = 'POOL_POOLSIZE_LIMIT'
+    self._doCallback(cb,[err,false]);
+  }
+}
+
+Pool.prototype.alloc = function(cb,shift) {
+  if ('function' === typeof cb) {
+    var self = this;    
+    this._getUnallocatedConnection(function(err,conn) {      
+      if ( err ) {
+        if ( err.code && err.code == 'POOL_POOLSIZE_LIMIT' ) {
+          self._queueAllocation(cb,shift);
+        } else {          
+          self._doCallback(cb,[err]);
+        }
+      } else if (conn && conn._socket) {  
+        self._doCallback(cb,[false,conn]);
+      } else {
+        self._queueAllocation(cb,shift);
+      }
+    });
+  } else {
+    throw new Error("Callback not provided to alloc");
+  }
+}
+
+Pool.prototype.free = function(conn) {
+  var self = this;
+  if (this.options.endOnRelease === true) {
+    conn.end();
+  } else if (this.options.resetSessionOnRelease === true) {    
+    conn.changeUser( this._onChangeUser.bind(this,conn) );
+  } else {
+    this._doRelease(conn);
+  }
+}
+Pool.prototype.dealloc = Pool.prototype.free;
+Pool.prototype.release = Pool.prototype.free;
+
+Pool.prototype.query = function(sql,values,cb) {
+  if (typeof values === 'function') {
+    cb     = values;
+    values = null;
+  }
+  
+  var self    = this;
+  var allocCb = function(err,conn) {
+    if (err) {
+      cb(err);
+    } else {
+      conn.query(sql,values,function(err,info) {        
+        cb(err,info);
+      });
+    }
+    self.free(conn);
+  }
+  
+  this.alloc(allocCb);
+}
+
+Pool.prototype.end = function() {  
+  this.connections.forEach( function(conn){
+    conn.end();   
+  });
+}
+Pool.prototype.escape = Connection.prototype.escape;
+
+
+Pool.prototype._addEventListeners = function(conn) {
+  conn.on('error', this._onConnectionError.bind(this, conn));
+  conn.on('close', this._onConnectionClose.bind(this, conn));
+  conn.on('end', this._onConnectionClose.bind(this, conn));
+}
+
+Pool.prototype._doCallback = function(cb,args){
+  if ('function' === typeof cb) {
+    cb.apply(undefined,args);
+  }
+}
+
+Pool.prototype._doRelease = function(conn){
+  conn.allocated = false;
+  this._onRelease();
+}
+/*
+Pool.prototype._findUnallocated = function(conn,idx,list) {
+  var connGood = (! conn.allocated) && (conn._socket);
+  if ( connGood ) { 
+    conn.allocated = true;
+    return true;
+  }
+  
+  return false;
+}*/
+Pool.prototype._findUnallocated = function(){
+  var conn;
+  for (var i = 0; i<this.connections.length; i++) {
+    conn         = this.connections[i];
+    var connGood = (! conn.allocated) && (conn._socket);
+    if (connGood) {
+      conn.allocated = true;
+      return conn;
+    }
+  }
+  return false;
+}
+Pool.prototype._getUnallocatedConnection = function(cb) {
+  var conn = this._findUnallocated();   
+  var self = this;
+  if (! conn ) {
+    var canConnect = this.connections.length < this.options.poolSize;
+    if ( canConnect) {
+      //need to go nextTick or multiple creates in same
+      //cycle will cause a Connection lost error
+      process.nextTick( this.createConnection.bind(self,cb) );
+    } else {
+      this._doCallback(cb,[false,false]);
+    }
+  } else {
+    this._doCallback(cb,[false,conn]);
+  }
+}
+Pool.prototype._onChangeUser = function(conn,err) {
+  if (err) {
+    conn.emit('error',err);
+  } else {
+    this._doRelease(conn);
+  }
+}
+Pool.prototype._onConnectionClose = function(conn) {
+  this._removeConnection(conn);
+}
+
+Pool.prototype._onConnectionError = function(conn,err) {
+  if (err.fatal) {
+    this._removeConnection(conn);
+  }
+  //emit error and connection it relates to
+  this.emit('error',err,conn);
+}
+
+Pool.prototype._onRelease = function() {
+  if (this.allocRequests.length > 0){  
+    var cb = this.allocRequests.shift();
+    this.alloc(cb,true);
+  }
+}
+
+Pool.prototype._queueAllocation = function(cb,shift) {
+  if (shift){
+    this.allocRequests.unshift(cb);
+  } else {
+    this.allocRequests.push(cb);
+  }
+}
+
+Pool.prototype._removeConnection = function(conn) {
+  var idx  = this.connections.indexOf(conn);
+  var self = this;
+
+  if (idx >= 0 ) {
+    var removed = self.connections.splice(idx,1);
+    removed.forEach(function(conn){
+      self.emit('removed',conn);
+    });
+  }
+  
+  this._onRelease();
+}

--- a/test/pool/test-bad-credentials.js
+++ b/test/pool/test-bad-credentials.js
@@ -1,0 +1,17 @@
+var common     = require('../common');
+var Pool       = require('../../lib/Pool');
+var pool = new Pool({password: 'INVALID PASSWORD'});
+var assert     = require('assert');
+
+var err;
+pool.alloc(function(_err,conn){
+  assert.equal(err,undefined);
+  err = _err
+});
+
+
+process.on('exit', function() {
+  assert.equal(err.code, 'ER_ACCESS_DENIED_ERROR');
+  assert.ok(/access denied/i.test(err.message));
+});
+

--- a/test/pool/test-change-user.js
+++ b/test/pool/test-change-user.js
@@ -1,0 +1,58 @@
+var common     = require('../common');
+var Pool       = require('../../lib/Pool');
+var _          = require('underscore');
+var pool       = new Pool(null,{
+  poolSize: 10,
+  endOnRelease: false,
+  createConnection: common.createConnection,
+  resetSessionOnRelease: true,
+});
+var assert     = require('assert');
+
+function checkDatabase(expectedDB,client,cb){
+  var sql = "select database() as `db`";
+  client.query(sql,function(err,info){
+    if (err) {
+      throw err;
+    }
+    assert.equal(info[0]['db'],expectedDB);
+    cb(client);
+  });
+}
+function changeDB(dbName,client,cb) {
+  client.changeUser({database:dbName},cb);
+}
+function step(fn,err,info){
+
+}
+var rows = undefined;
+
+for (var i = 0; i< 20; i++){
+  pool.alloc(function(err,client){
+    if (err) {
+      throw (err);
+    } else {
+      checkDatabase(null,client, function(client){
+        changeDB('test', client, function(err){
+          if (err) {
+            throw err;
+          }
+          checkDatabase('test',client, function(client){
+            pool.free(client);
+          });
+        });
+      });
+    }
+  });  
+}
+
+setTimeout(function(){
+  pool.end();
+},5000);
+
+
+process.on('exit', function() {
+  //see if we can find an "free" connection, we should not
+  var conn = pool._findUnallocated();
+  assert.equal(conn,false);
+});

--- a/test/pool/test-parallel-select-1.js
+++ b/test/pool/test-parallel-select-1.js
@@ -1,0 +1,46 @@
+var common     = require('../common');
+var Pool       = require('../../lib/Pool');
+var _          = require('underscore');
+var pool       = new Pool(null,{
+  poolSize: 10,
+  endOnRelease: false,
+  createConnection: common.createConnection.bind(undefined,{
+    multipleStatements: true})
+});
+var assert     = require('assert');
+
+var rows = undefined;
+
+for (var i = 0; i<20; i++){
+  pool.alloc(function(err,conn){
+    if (err) {
+      throw (err);
+    } else {
+      conn.on('error',function(err){
+        console.log(err);
+      });
+      conn.query("SELECT SLEEP(2);SELECT ? AS `connection.id`;",[conn.id],
+        function( err, info ) {
+          if (err) {
+            throw (err);
+          } else {
+            //assert conn.id < default pool size          
+            assert.equal(true, ( info[1][0]['connection.id'] < pool.options.poolSize));            
+          }
+          pool.release(conn); //or pool.free or pool.dealloc
+        }
+      );
+    }
+  });  
+}
+
+setTimeout(function(){
+  pool.end();
+},10000);
+
+
+process.on('exit', function() {
+  //see if we can find an "free" connection, we should not  
+  var conn = pool._findUnallocated();
+  assert.equal(conn,false);
+});

--- a/test/pool/test-select-1.js
+++ b/test/pool/test-select-1.js
@@ -1,0 +1,23 @@
+var common     = require('../common');
+var Pool       = require('../../lib/Pool');
+var pool = new Pool(null,{
+  poolSize: 10,
+  createConnection: common.createConnection
+});
+var assert     = require('assert');
+
+
+var rows = undefined;
+pool.query('SELECT 1', function(err, _rows) {
+  if (err) throw err;
+
+  rows = _rows;
+});
+
+setTimeout(function(){
+  pool.end();
+},2000);
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{1: 1}]);
+});

--- a/test/pool/test-type-cast-query.js
+++ b/test/pool/test-type-cast-query.js
@@ -1,0 +1,22 @@
+var common     = require('../common');
+var Pool       = require('../../lib/Pool');
+var pool = new Pool(null,{
+  poolSize: 10,
+  createConnection: common.createConnection.bind(undefined,{
+    typeCast: false
+  })
+});
+var assert     = require('assert');
+
+
+var rows = undefined;
+var query = pool.query("SELECT NOW() as date", function(err, _rows) {
+  if (err) throw err;
+
+  rows = _rows;
+  pool.end();
+});
+
+process.on('exit', function() {
+  assert.strictEqual(typeof rows[0].date, 'string');
+});

--- a/test/pool/test-type-casting.js
+++ b/test/pool/test-type-casting.js
@@ -1,0 +1,103 @@
+var common     = require('../common');
+var Pool       = require('../../lib/Pool');
+var pool = new Pool(null,{
+  poolSize: 10,
+  createConnection: common.createConnection.bind(undefined,{
+    typeCast: true
+  })
+});
+var assert     = require('assert');
+var expected = {
+  'DECIMAL'    : '0.330',
+  'TINYINT'    : 1,
+  'SMALLINT'   : 2,
+  'INT'        : 3,
+  'FLOAT'      : 4.5,
+  'DOUBLE'     : 5.5,
+  'BIGINT'     : '6',
+  'MEDIUMINT'  : 7,
+  'YEAR'       : 2012,
+  'TIMESTAMP'  : new Date('2012-05-12 11:00:23'),
+  'DATETIME'   : new Date('2012-05-12 11:02:32'),
+  'DATE'       : new Date('2012-05-12'),
+  'TIME'       : '13:13:23',
+  'BINARY'     : new Buffer([0, 1, 254, 255]),
+  'VARBINARY'  : new Buffer([0, 1, 254, 255]),
+  'TINYBLOB'   : new Buffer([0, 1, 254, 255]),
+  'MEDIUMBLOB' : new Buffer([0, 1, 254, 255]),
+  'LONGBLOB'   : new Buffer([0, 1, 254, 255]),
+  'BLOB'       : new Buffer([0, 1, 254, 255]),
+  'BIT'        : new Buffer([0, 1, 254, 255]),
+  'CHAR'       : 'Hello',
+  'VARCHAR'    : 'Hello',
+  'TINYTEXT'   : 'Hello World',
+  'MEDIUMTEXT' : 'Hello World',
+  'LONGTEXT'   : 'Hello World',
+  'TEXT'       : 'Hello World',
+};
+var row;
+pool.alloc( function(err,connection){
+  if ( err ) {
+    throw err;
+  }
+  common.useTestDb(connection);
+
+  var schema  = [];
+  var inserts = [];
+  for (var key in expected) {
+    var value = expected[key];
+    var type = key;
+    if (type === 'DECIMAL') {
+      type = type + '(3,3)';
+    } else if (/binary|char/i.test(type)) {
+      type = type + '(' + value.length + ')';
+    } else if (/bit/i.test(type)) {
+      type = type + '(' + (value.length * 8) + ')';
+    }
+
+    var escaped = connection.escape(value);
+
+    schema.push('`' + key + '` ' + type + ',');
+    inserts.push('`' + key + '` = ' + escaped);
+  }
+
+  connection.query([
+    'CREATE TEMPORARY TABLE `type_casting` (',
+    '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+    ].concat(schema).concat([
+    'PRIMARY KEY (`id`)',
+    ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+  ]).join('\n'));
+
+  connection.query('INSERT INTO type_casting SET' + inserts.join(',\n'));
+  
+  connection.query('SELECT * FROM type_casting', function(err, rows) {
+    if (err) throw err;
+
+    row = rows[0];
+    
+  });
+    
+});
+
+setTimeout(function(){
+  pool.end();
+},10000);
+
+
+process.on('exit', function() {
+  for (var key in expected) {
+    var expectedValue = expected[key];
+    var actualValue   = row[key];
+
+    if (expectedValue instanceof Date) {
+      expectedValue = Number(expectedValue);
+      actualValue   = Number(actualValue);
+    } else if (Buffer.isBuffer(expectedValue)) {
+      expectedValue = Array.prototype.slice.call(expectedValue)+'';
+      actualValue   = Array.prototype.slice.call(actualValue)+'';
+    }
+
+    assert.strictEqual(actualValue, expectedValue, key + ': ' + actualValue + ' !== ' + expectedValue);
+  }
+});


### PR DESCRIPTION
Note that the resetSessionOnRelease pool option requires a connection method 'changeUser' per the other pull request.  The connection pool will work without it as long as that option is not set to true; if it is, an error will be throw.
