### PR TITLE
v2.0 Don't double-replace question marks.

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -53,8 +53,12 @@ function zeroPad(number) {
 SqlString.format = function(sql, values) {
   values = [].concat(values);
 
-  values.forEach(function(value) {
-    sql = sql.replace('?', SqlString.escape(value));
+  sql = sql.replace(/\?/g, function() {
+    if (values.length == 0) {
+      throw new Error('too few parameters given');
+    }
+    
+    return SqlString.escape(values.shift());
   });
 
   return sql;


### PR DESCRIPTION
Right now, v2.0 will replace question marks in arguments if there are any. For example,

``` javascript
connection.query('SELECT * FROM table WHERE name = ? AND type = ?',
    ['Hello?', 'World!']);
```

will run a query like "SELECT \* FROM table WHERE name = 'Hello'World!'' AND type = ?" , not the expected "SELECT \* FROM table WHERE name = 'Hello?' AND type = 'World!'". This appears to be a regression in v2.0, so this just changes back to 0.9.6-ish behavior/code.

I haven't tested the performance implications of leaving the regexp in the query function versus pulling it out as a separate variable and only evaluating it once, but this is the way it was done in 0.9.6. (Also, simply iterating an index over the values array may be faster than using .shift().)
