### PR TITLE
Unable to reuse objects returned by a query in another query.

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -92,7 +92,8 @@ SqlString.objectToValues = function(object) {
   var values = [];
   for (var key in object) {
     var value = object[key];
-    values.push('`' + key + '` = ' + SqlString.escape(value, true));
+    if(typeof value !== 'function')
+      values.push('`' + key + '` = ' + SqlString.escape(value, true));
   }
 
   return values.join(', ');


### PR DESCRIPTION
This addresses the problem when trying to update rows received from query call. For example:

```
conn.query('SELECT * FROM users WHERE id = 1', function(err, users)
{
    var user = users[0];

    user.counter++;

    conn.query('REPLACE INTO users SET ?', user, function(err, info) {});
});
```

This would cause a problem because RowDataPacket has functions and SqlString.objectToValues() would try to escape them like any other values.
