### PR TITLE
Inverted for loops execute faster.

### DIFF
--- a/lib/protocol/packets/RowDataPacket.js
+++ b/lib/protocol/packets/RowDataPacket.js
@@ -6,8 +6,8 @@ function RowDataPacket() {
 }
 
 RowDataPacket.prototype.parse = function(parser, fieldPackets, typeCast, nestTables) {
-  for (var i = 0; i < fieldPackets.length; i++) {
-    var fieldPacket = fieldPackets[i];
+  for (var i = fieldPackets.length; i > 0; i--) {
+    var fieldPacket = fieldPackets[i - 1];
 
     var value = (typeCast)
       ? this._typeCast(fieldPacket, parser)


### PR DESCRIPTION
When running a for loop over the length of an array, it is faster to cache the length of the array and run bottom to top
