### PR TITLE
Fixed queried BLOBs changing over time

### DIFF
--- a/lib/protocol/Parser.js
+++ b/lib/protocol/Parser.js
@@ -220,10 +220,13 @@ Parser.prototype.parsePacketTerminatedString = function() {
 };
 
 Parser.prototype.parseBuffer = function(length) {
-  var buffer = this._buffer.slice(this._offset, this._offset + length);
+	var response = new Buffer(length);
 
-  this._offset += length;
-  return buffer;
+	this._buffer.copy(response, 0, this._offset, this._offset + length);
+
+	this._offset += length;
+
+	return response;
 };
 
 Parser.prototype.parseString = function(length) {

--- a/test/unit/protocol/test-Parser.js
+++ b/test/unit/protocol/test-Parser.js
@@ -13,6 +13,22 @@ function packet(bytes) {
 }
 
 test('Parser', {
+  "parseBuffer: buffer won\'t change after appending another one": function() {
+    var startBuffer = new Buffer(5);
+    startBuffer.fill('a');
+
+    var parser = new Parser();
+    parser.append(startBuffer);
+
+    var value = parser.parseBuffer(4);
+
+    assert.equal(value.toString(), 'aaaa');
+
+    parser.append(new Buffer('b'));
+
+    assert.equal(value.toString(), 'aaaa');
+  },
+
   'parseUnsignedNumber: 1 byte': function() {
     var value = packet([5]).parseUnsignedNumber(1);
     assert.equal(value, 5);


### PR DESCRIPTION
As per [Buffer docs](http://nodejs.org/api/buffer.html#buffer_buf_slice_start_end), **Modifying the new buffer slice will modify memory in the original buffer!**, so using slice in `Parser.parseBuffer` leaves the resulting buffers queries from the DB changeable when a new append happens.

Effective results are blobs fetched from mysql are wrong before they are passed to the query callback.

Test case included.
