### PR TITLE
Add Connection.call() to call procedures and return out variables

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -90,6 +90,40 @@ Connection.prototype.query = function(sql, values, cb) {
   return this._protocol.query(options, cb);
 };
 
+Connection.prototype.call = function(procedure, values, cb) {
+  if (typeof values == 'function') {
+    cb     = values;
+    values = undefined;
+  }
+
+  this.query("CALL " + procedure, values, function (err) {
+    if (err) return cb(err);
+
+    var m = procedure.match(/(@[a-z0-9_\.\$]+|@'.*?'|@".*?"|@`.*?`)/ig);
+    if (m === null) {
+      // no parameters used, just return
+      return cb(null);
+    }
+
+    this.query("SELECT " + m.join(', '), function (err, data) {
+      if (err) return cb(err);
+
+      var results = {};
+      for (var k in data[0]) {
+        if (!data[0].hasOwnProperty(k)) continue;
+
+        if ([ '\'', '"', '`' ].indexOf(k[1]) >= 0 && k[1] == k.substr(-1)) {
+          results[k.substr(2, k.length - 3)] = data[0][k];
+        } else {
+          results[k.substr(1)] = data[0][k];
+        }
+      }
+
+      return cb(null, results);
+    });
+  }.bind(this));
+};
+
 Connection.prototype.ping = function(cb) {
   this._implyConnect();
   this._protocol.ping(cb);

--- a/test/integration/connection/test-call.js
+++ b/test/integration/connection/test-call.js
@@ -1,0 +1,24 @@
+var common     = require('../../common');
+var connection = common.createConnection();
+var assert     = require('assert');
+
+common.useTestDb(connection);
+
+var procedure = 'call_test';
+
+connection.query([
+  'CREATE PROCEDURE `' + procedure + '` (',
+  'IN `val` int(11),',
+  'OUT `dup` int(11))',
+  'BEGIN',
+  ' SET `dup` = `val` * 2;',
+  'END'
+].join('\n'));
+
+connection.call(procedure + "(10, @double)", function (err, data) {
+  assert.equal(err, null);
+  assert.deepEqual(data, { double: 20 });
+
+  connection.query("DROP PROCEDURE `" + procedure + "`");
+  connection.end();
+});


### PR DESCRIPTION
Motivation:
- More than one statement is not allowed by default. Calling procedures and fetching output variables needs 2 calls. This avoids having 2 nested queries.

Example:

``` js
var mysql = require("mysql");
var connection = mysql.createConnection("...");

connection.call("my_procedure('a', 34, @foo, @bar)", function (err, data) {
  // if no error occurs, data = { foo: ... , bar: ... }
});
```

Related: #287
