### PR TITLE
Accept prebuilt Query object in connection.query

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@ var Connection       = require('./lib/Connection');
 var ConnectionConfig = require('./lib/ConnectionConfig');
 var Types            = require('./lib/protocol/constants/types');
 var SqlString        = require('./lib/protocol/SqlString');
-var Query            = require('./lib/protocol/sequences/Query');
 
 exports.createConnection = function(config) {
   return new Connection({config: new ConnectionConfig(config)});
 };
 
+exports.createQuery = Connection.createQuery;
+
 exports.Types    = Types;
-exports.Query    = Query;
 exports.escape   = SqlString.escape;
 exports.escapeId = SqlString.escapeId;

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -2,7 +2,7 @@ var Net              = require('net');
 var ConnectionConfig = require('./ConnectionConfig');
 var Protocol         = require('./protocol/Protocol');
 var SqlString        = require('./protocol/SqlString');
-var Sequences        = require('./protocol/sequences');
+var Query            = require('./protocol/sequences/Query');
 var EventEmitter     = require('events').EventEmitter;
 var Util             = require('util');
 
@@ -17,6 +17,30 @@ function Connection(options) {
   this._protocol      = new Protocol({config: this.config, connection: this});
   this._connectCalled = false;
 }
+
+Connection.createQuery = function(sql, values, cb) {
+  if (sql instanceof Query) {
+    return sql;
+  }
+
+  var options = {};
+
+  if (typeof sql === 'object') {
+    // query(options, cb)
+    options = sql;
+    cb      = values;
+  } else if (typeof values === 'function') {
+    // query(sql, cb)
+    cb             = values;
+    options.sql    = sql;
+    options.values = undefined;
+  } else {
+    // query(sql, values, cb)
+    options.sql    = sql;
+    options.values = values;
+  }
+  return new Query(options, cb);
+};
 
 Connection.prototype.connect = function(cb) {
   if (!this._connectCalled) {
@@ -62,38 +86,16 @@ Connection.prototype.changeUser = function(options, cb){
 Connection.prototype.query = function(sql, values, cb) {
   this._implyConnect();
 
-  var options = {};
+  var query = Connection.createQuery(sql, values, cb);
 
-  if (sql instanceof Sequences.Query) {
-    // query(new Sequences.Query(options, cb))
-    return this._protocol._enqueue(sql);
-  }
-  
-  if (typeof sql === 'object') {
-    // query(options, cb)
-    options = sql;
-    cb      = values;
-    values  = options.values;
-
-    delete options.values;
-  } else if (typeof values === 'function') {
-    // query(sql, cb)
-    cb          = values;
-    options.sql = sql;
-    values      = undefined;
-  } else {
-    // query(sql, values, cb)
-    options.sql    = sql;
-    options.values = values;
+  if (!(typeof sql == 'object' && 'typeCast' in sql)) {
+    query.typeCast = this.config.typeCast;
   }
 
-  options.sql = this.format(options.sql, values || []);
+  query.sql = this.format(query.sql, query.values || []);
+  delete query.values;
 
-  if (!('typeCast' in options)) {
-    options.typeCast = this.config.typeCast;
-  }
-
-  return this._protocol.query(options, cb);
+  return this._protocol._enqueue(query);
 };
 
 Connection.prototype.ping = function(cb) {

--- a/lib/protocol/sequences/Query.js
+++ b/lib/protocol/sequences/Query.js
@@ -11,6 +11,7 @@ function Query(options, callback) {
   Sequence.call(this, callback);
 
   this.sql = options.sql;
+  this.values = options.values;
   this.typeCast = (options.typeCast === undefined)
     ? true
     : options.typeCast;


### PR DESCRIPTION
This allows support code to construct a Query instance to be used with
a connection made available in the future.

My use case is making this [ConnectionPool.query](https://github.com/grncdr/node-any-db/blob/ebee211f4f068f80bde199182124cae3fc1770f5/lib/connection-pool.js#L55) method from any-db work directly with mysql `Query` instances rather than having to wrap them in an adapter (how it works now). By allowing a connection to execute an existing Query instance, we can return the user a query result object synchronously, meaning the user never needs to know about the internals of the connection pool. 
