### PR TITLE
Switch to old mode for Streams 2 (Node.js v 0.10.x)

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -56,6 +56,7 @@ Connection.prototype.connect = function(cb) {
       ? Net.createConnection(this.config.socketPath)
       : Net.createConnection(this.config.port, this.config.host);
 
+    this._socket.on("data",function() {});
     this._socket.pipe(this._protocol);
     this._protocol.pipe(this._socket);
 


### PR DESCRIPTION
Following the streaming example in the docs (i.e. defining query without a callback and listening to 'result') I get an error when I pause the connection (node v0.0.11).

> Error: Cannot switch to old mode now.
>   at emitDataEvents (_stream_readable.js:683:11)
> at Socket.Readable.pause (_stream_readable.js:674:3)
> at Connection.pause (c:\program files\nodejs\node_modules\mysql\lib\Connect.....

This error only affects Streaming usage and only shows up when I try to pause.

I'm not an expert on the subject, but the small patch included (i.e. placing a noop listener on data) seems to do the trick.  By defining a data listener (before piping) the underlying stream is switched to old mode soon enough.  I have not done any extensive tests, so please look at this more of a suggestion.  I guess a proper solution would be to align the code to the new streams rather than patching into the old?
