### PR TITLE
Usability fixes in readme and package.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Sometimes I may also ask you to install the latest version from Github to check
 if a bugfix is working. In this case, please do:
 
 ```
-npm install git://github.com/felixge/node-mysql.git
+npm install felixge/node-mysql
 ```
 
 [v0.9 branch]: https://github.com/felixge/node-mysql/tree/v0.9

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A node.js driver for mysql. It is written in JavaScript, does not require compiling, and is 100% MIT licensed.",
   "version": "2.0.0-alpha7",
   "repository": {
-    "url": ""
+    "type": "git",
+    "url": "https://github.com/felixge/node-mysql"
   },
   "main": "./index",
   "scripts": {


### PR DESCRIPTION
- shorter npm install for git
- git url in package.json: it useful when user come from npmjs.org/packages/node-mysql. Currently it says "Repository    (undefined)" but it should link to github.
