### PR TITLE
Add bigNumberStrings option for forcing BIGINTs as strings (always)

### DIFF
--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -16,6 +16,7 @@ function ConnectionConfig(options) {
   this.database           = options.database;
   this.insecureAuth       = options.insecureAuth || false;
   this.supportBigNumbers  = options.supportBigNumbers || false;
+  this.bigNumberStrings   = options.bigNumberStrings || false;
   this.debug              = options.debug;
   this.timezone           = options.timezone || 'local';
   this.flags              = options.flags || '';

--- a/lib/protocol/packets/RowDataPacket.js
+++ b/lib/protocol/packets/RowDataPacket.js
@@ -10,7 +10,7 @@ function RowDataPacket() {
 RowDataPacket.prototype.parse = function(parser, fieldPackets, typeCast, nestTables, connection) {
   var self = this;
   var next = function () {
-    return self._typeCast(fieldPacket, parser, connection.config.timezone, connection.config.supportBigNumbers);
+    return self._typeCast(fieldPacket, parser, connection.config.timezone, connection.config.supportBigNumbers, connection.config.bigNumberStrings);
   };
 
   for (var i = 0; i < fieldPackets.length; i++) {
@@ -21,7 +21,7 @@ RowDataPacket.prototype.parse = function(parser, fieldPackets, typeCast, nestTab
       value = typeCast.apply(connection, [ new Field({ packet: fieldPacket, parser: parser }), next ]);
     } else {
       value = (typeCast)
-        ? this._typeCast(fieldPacket, parser, connection.config.timezone, connection.config.supportBigNumbers)
+        ? this._typeCast(fieldPacket, parser, connection.config.timezone, connection.config.supportBigNumbers, connection.config.bigNumberStrings)
         : ( (fieldPacket.charsetNr === Charsets.BINARY)
           ? parser.parseLengthCodedBuffer()
           : parser.parseLengthCodedString() );
@@ -38,7 +38,9 @@ RowDataPacket.prototype.parse = function(parser, fieldPackets, typeCast, nestTab
   }
 };
 
-RowDataPacket.prototype._typeCast = function(field, parser, timeZone, supportBigNumbers) {
+RowDataPacket.prototype._typeCast = function(field, parser, timeZone, supportBigNumbers, bigNumberStrings) {
+  var numberString;
+
   switch (field.type) {
     case Types.TIMESTAMP:
     case Types.DATE:
@@ -72,12 +74,15 @@ RowDataPacket.prototype._typeCast = function(field, parser, timeZone, supportBig
     case Types.YEAR:
     case Types.FLOAT:
     case Types.DOUBLE:
-    case Types.LONGLONG:
     case Types.NEWDECIMAL:
-      var numberString = parser.parseLengthCodedString();
+      numberString = parser.parseLengthCodedString();
+      return (numberString === null || (field.zeroFill && numberString[0] == "0"))
+        ? numberString : Number(numberString);
+    case Types.LONGLONG:
+      numberString = parser.parseLengthCodedString();
       return (numberString === null || (field.zeroFill && numberString[0] == "0"))
         ? numberString
-        : ((supportBigNumbers && Number(numberString) > IEEE_754_BINARY_64_PRECISION)
+        : ((supportBigNumbers && (bigNumberStrings || (Number(numberString) > IEEE_754_BINARY_64_PRECISION)))
           ? numberString
           : Number(numberString));
     case Types.BIT:


### PR DESCRIPTION
Hi there. It is just as the title mentions.

I have followed felixge/node-mysql#207 attentively, but in one
app I am developing we use lots of BIGINT columns.
I am aware that using supportBigNumbers:true handles big numbers
in case hey cannot be accurately represented returning them as strings.
In our app, it is easiest to assume that they will be always strings,
and it is quite a pain and error-prone for us to convert all BIGINTs
to strings, so we added this option.

I would be happy if you could push these commits in your repo.
Thank you in advance.
