### PR TITLE
Removed slow unnecessary stack access

### DIFF
--- a/lib/protocol/sequences/Sequence.js
+++ b/lib/protocol/sequences/Sequence.js
@@ -12,7 +12,7 @@ function Sequence(callback) {
   this._ended            = false;
 
   // Experimental: Long stack trace support
-  this._callSite = (new Error).stack.replace(/.+\n/, '');
+  this._callSite = new Error;
 }
 
 Sequence.determinePacket = function(byte) {
@@ -41,7 +41,7 @@ Sequence.prototype._addLongStackTrace = function(err) {
     return;
   }
 
-  err.stack += delimiter + this._callSite;
+  err.stack += delimiter + this._callSite.stack.replace(/.+\n/, '');
 };
 
 Sequence.prototype.end = function(err) {


### PR DESCRIPTION
Issue: https://github.com/felixge/node-mysql/issues/439

Error is still initialized at the same position, but stack is only access if needed.
