### PR TITLE
Add stream method to Query

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -98,6 +98,7 @@ Connection.prototype.query = function(sql, values, cb) {
   this._implyConnect();
 
   var query = Connection.createQuery(sql, values, cb);
+  query._connection = this;
 
   if (!(typeof sql == 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.typeCast;

--- a/lib/protocol/sequences/Query.js
+++ b/lib/protocol/sequences/Query.js
@@ -4,6 +4,7 @@ var Packets      = require('../packets');
 var ResultSet    = require('../ResultSet');
 var ServerStatus = require('../constants/server_status');
 var fs           = require('fs');
+var Readable     = require('stream').Readable;
 
 module.exports = Query;
 Util.inherits(Query, Sequence);
@@ -163,4 +164,36 @@ Query.prototype._sendLocalDataFile = function(path) {
 
     self.emit('packet', new Packets.EmptyPacket());
   });
+};
+
+Query.prototype.stream = function(options) {
+  var self = this,
+      stream;
+
+  options = options || {};
+  options.objectMode = true;
+  stream = new Readable(options),
+
+  stream._read = function() {
+    self._connection.resume();
+  };
+
+  this.on("result",function(row,i) {
+    if (!stream.push(row)) self._connection.pause();
+    stream.emit("result",row,i);  // replicate old emitter
+  });
+
+  this.on("error",function(err) {
+    stream.emit('error',err);  // Pass on any errors
+  });
+
+  this.on("end", function() {
+    stream.push(null);  // pushing null, indicating EOF
+  });
+
+  this.on("fields",function(fields,i) {
+    stream.emit('fields",fields',i);  // replicate old emitter
+  });
+
+  return stream;
 };


### PR DESCRIPTION
Wraps events from the query object into a node v0.10.x Readable stream.
See demo https://gist.github.com/ZJONSSON/5314920

I also played with the idea of simply changing the Sequence object from an eventEmitter to a Readable stream (see https://github.com/ZJONSSON/node-mysql/commit/58ffaf3b81de54a5fabe79833de1f1a9b9fd7f31).   In that case the query object can be streamed directly without calling `.stream()`.  Original events dispatched as before. 
