### PR TITLE
Wrong bracketing in FieldPacket.write

### DIFF
--- a/lib/protocol/packets/FieldPacket.js
+++ b/lib/protocol/packets/FieldPacket.js
@@ -63,7 +63,7 @@ FieldPacket.prototype.write = function(writer) {
     writer.writeFiller(1);
     writer.writeUnsignedNumber(2, this.charsetNr || 0);
     writer.writeUnsignedNumber(4, this.fieldLength || 0);
-    writer.writeUnsignedNumber(1, this.type) || 0;
+    writer.writeUnsignedNumber(1, this.type || 0);
     writer.writeUnsignedNumber(2, this.flags || 0);
     writer.writeUnsignedNumber(1, this.decimals || 0);
     writer.writeFiller(2);


### PR DESCRIPTION
The argument should be defaulted to zero, not the (ignored) result
