### PR TITLE
Add Pool option queueLimit

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -38,7 +38,11 @@ Pool.prototype.getConnection = function(cb) {
       }
     });
   } else if (this.config.waitForConnections) {
-    this._connectionQueue.push(cb);
+    if (this.config.queueLimit && this._connectionQueue.length >= this.config.queueLimit) {
+      cb(new Error('Queue limit reached.'))
+    } else {
+      this._connectionQueue.push(cb);
+    }
   } else {
     cb(new Error('No connections available.'));
   }

--- a/lib/PoolConfig.js
+++ b/lib/PoolConfig.js
@@ -11,4 +11,7 @@ function PoolConfig(options) {
   this.connectionLimit    = (options.connectionLimit === undefined)
     ? 10
     : Number(options.connectionLimit);
+  this.queueLimit         = (options.queueLimit === undefined)
+    ? 0
+    : Number(options.queueLimit);
 }

--- a/test/integration/pool/test-queue-limit.js
+++ b/test/integration/pool/test-queue-limit.js
@@ -1,0 +1,28 @@
+var common = require('../../common');
+var assert = require('assert');
+var pool   = common.createPool({
+  connectionLimit    : 1,
+  queueLimit         : 1,
+  waitForConnections : true
+});
+
+// First connection we get right away
+pool.getConnection(function(err, connection) {
+	connection.end()
+})
+
+// Second connection request goes into the queue
+pool.getConnection(function(err, connection) {
+	connection.end()
+	pool.end()
+})
+
+// Third connection request gets refused, since the queue is full
+var thirdGetErr
+pool.getConnection(function(err, connection) {
+	thirdGetErr = err
+})
+
+process.on('exit', function() {
+	assert.equal(thirdGetErr.message, 'Queue limit reached.')	
+})


### PR DESCRIPTION
Add Pool option queueLimit, which returns an error to Pool#getConnection if the queue of pending connection requests gets larger than the queueLimit. This is a safeguard to detect code which leaks connections sooner rather than later. The new functionality covered in test/integration/pool/test-queue-limit.js
