### PR TITLE
fix writing charsetNumber in ComChangeUserPacket with 2 bytes

### DIFF
--- a/lib/protocol/packets/ComChangeUserPacket.js
+++ b/lib/protocol/packets/ComChangeUserPacket.js
@@ -21,5 +21,5 @@ ComChangeUserPacket.prototype.write = function(writer) {
   writer.writeNullTerminatedString(this.user);
   writer.writeLengthCodedBuffer(this.scrambleBuff);
   writer.writeNullTerminatedString(this.database);
-  writer.writeUnsignedNumber(1, this.charsetNumber);
+  writer.writeUnsignedNumber(2, this.charsetNumber);
 };


### PR DESCRIPTION
The related issue:
https://github.com/felixge/node-mysql/issues/482
