### PR TITLE
Date#parse requires a space between the seconds part and the timezone

### DIFF
--- a/lib/protocol/packets/RowDataPacket.js
+++ b/lib/protocol/packets/RowDataPacket.js
@@ -57,7 +57,7 @@ RowDataPacket.prototype._typeCast = function(field, parser, timeZone, supportBig
         if (field.type === Types.DATE) {
           dateString += ' 00:00:00 ' + timeZone;
         } else {
-          dateString += timeZone;
+          dateString += ' ' + timeZone;
         }
       }
 


### PR DESCRIPTION
The current logic results in `dateString` being set to e.g. `2005-02-15 00:00:00UTC` for DATETIME fields if UTC is set as the timezone. This results in an invalid date when passed to the `Date` constructor, or `NaN` when passed to `Date.parse` (the operation is the same internally for both methods).

With the fix, the date is parsed correctly.
