### PR TITLE
Make sure pool requests always behave asynchronously

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -15,7 +15,7 @@ function Pool(options) {
 
 Pool.prototype.getConnection = function (cb) {
   if (this._closed) {
-    process.nextTick(function(){
+    return process.nextTick(function(){
       return cb(new Error('Pool is closed.'));
     });
   }
@@ -48,7 +48,7 @@ Pool.prototype.getConnection = function (cb) {
   }
 
   if (!this.config.waitForConnections) {
-    process.nextTick(function(){
+    return process.nextTick(function(){
       return cb(new Error('No connections available.'));
     });
   }


### PR DESCRIPTION
Minor edits to make sure pool requests always behave asynchronously.
