### PR TITLE
Don't delete query values after formatting

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -105,7 +105,6 @@ Connection.prototype.query = function(sql, values, cb) {
   }
 
   query.sql = this.format(query.sql, query.values || []);
-  delete query.values;
 
   return this._protocol._enqueue(query);
 };


### PR DESCRIPTION
Back when I submitted #358, I added a line to delete `query.values` after the query had been formatted. This pull request removes that line because it's very handy to be able to log them in a structured manner in parts of the code that wouldn't normally have access to the parameters.
