### PR TITLE
Closes #512

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -120,9 +120,14 @@ Connection.prototype.statistics = function(cb) {
   this._protocol.stats(cb);
 };
 
-Connection.prototype.end = function(cb) {
+Connection.prototype.release = function(cb) {
   this._implyConnect();
   this._protocol.quit(cb);
+};
+
+Connection.prototype.end = function(cb) {
+  console.warn('.end() is deprecated, please use .release()');
+  this.release();
 };
 
 Connection.prototype.destroy = function() {


### PR DESCRIPTION
.end() is an alias for .release() and warns via console.warn
