### PR TITLE
rename pooled connection `end` to `release`

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -116,6 +116,7 @@ Pool.prototype.end = function (cb) {
   for (var i = 0; i < this._allConnections.length; i++) {
     connection = this._allConnections[i];
 
+    delete connection.release;
     connection.destroy = connection._realDestroy;
     connection.end     = connection._realEnd;
     connection.end(endCB);
@@ -132,7 +133,7 @@ Pool.prototype.query = function (sql, values, cb) {
     if (err) return cb(err);
 
     conn.query(sql, values, function () {
-      conn.end();
+      conn.release();
       cb.apply(this, arguments);
     });
   });
@@ -146,8 +147,17 @@ Pool.prototype._createConnection = function() {
 
   connection._realEnd = connection.end;
   connection.end      = function(cb) {
-    self.releaseConnection(connection);
+    console.warn( 'Calling conn.end() to release a pooled connection is '
+                + 'deprecated. In next version calling conn.end() will be '
+                + 'restored to default conn.end() behavior. Use '
+                + 'conn.release() instead.'
+                );
+    this.release();
     if (cb) cb();
+  };
+
+  connection.release = function () {
+    self.releaseConnection(connection);
   };
 
   connection._realDestroy = connection.destroy;
@@ -198,6 +208,7 @@ Pool.prototype._removeConnection = function(connection) {
     }
   }
 
+  delete connection.release;
   connection.end     = connection._realEnd;
   connection.destroy = connection._realDestroy;
 

--- a/test/integration/pool/test-connection-limit.js
+++ b/test/integration/pool/test-connection-limit.js
@@ -21,6 +21,6 @@ pool.getConnection(function(err, connection) {
     });
 
     shouldGetConnection = true;
-    connection.end();
+    connection.release();
   });
 });

--- a/test/integration/pool/test-destroy-connection.js
+++ b/test/integration/pool/test-destroy-connection.js
@@ -11,7 +11,8 @@ pool.getConnection(function(err, connection) {
   assert.ok(pool._allConnections.length == 0);
   assert.ok(connection._poolRemoved);
   assert.strictEqual(connection.end,     Connection.prototype.end);
-  assert.strictEqual(connection.destroy, Connection.prototype.destroy);
+  assert.strictEqual(connection.end,     Connection.prototype.end);
+  assert.ok(!('release' in connection))
 
   pool.end();
 });

--- a/test/integration/pool/test-queue-limit.js
+++ b/test/integration/pool/test-queue-limit.js
@@ -8,12 +8,12 @@ var pool   = common.createPool({
 
 // First connection we get right away
 pool.getConnection(function(err, connection) {
-  connection.end()
+  connection.release()
 })
 
 // Second connection request goes into the queue
 pool.getConnection(function(err, connection) {
-  connection.end()
+  connection.release()
   pool.end()
 })
 


### PR DESCRIPTION
#517 has stagnated, so I'm opening this.

Fixes #512
