### PR TITLE
Allow access to the packet object

### DIFF
--- a/lib/protocol/packets/Field.js
+++ b/lib/protocol/packets/Field.js
@@ -5,6 +5,7 @@ function Field(options) {
   options = options || {};
 
   this.parser = options.parser;
+  this.packet = options.packet;
   this.db     = options.packet.db;
   this.table  = options.packet.table;
   this.name   = options.packet.name;


### PR DESCRIPTION
I'm trying to use some field packet information in my custom "typeCast" function, but right now the Field object don't have access to it.

"RowDataPacket.prototype._typeCast" function have access to it, and I need to check the field "charsetNr" property in my custom "typeCast" function but I can't because I don't have access to it.
