### PR TITLE
Fix missing tz in recursive arrayToList call

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -53,7 +53,7 @@ SqlString.escape = function(val, stringifyObjects, timeZone) {
 
 SqlString.arrayToList = function(array, timeZone) {
   return array.map(function(v) {
-    if (Array.isArray(v)) return '(' + SqlString.arrayToList(v) + ')';
+    if (Array.isArray(v)) return '(' + SqlString.arrayToList(v, timeZone) + ')';
     return SqlString.escape(v, true, timeZone);
   }).join(', ');
 };


### PR DESCRIPTION
I think that SqlString.arrayToList drops a timeZone parameter when nested arrayToList is called. To handle this problem I added timeZone to an argument list of nested arrayToList call.
