### PR TITLE
Fixed typo in code sample

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -388,6 +388,7 @@ function handleDisconnect() {
     } else {                                      // connnection idle timeout (the wait_timeout
       throw err;                                  // server variable configures this)
     }
+  });
 }
 
 handleDisconnect();


### PR DESCRIPTION
Typo in `handleDisconnect` sample
