### PR TITLE
Update Pool.js to allow calling Pool.prototype.query with no callback

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -127,7 +127,12 @@ Pool.prototype.query = function (sql, values, cb) {
   }
 
   this.getConnection(function (err, conn) {
-    if (err) return cb(err);
+    if (err) {
+      if (typeof cb === 'function') {
+        cb(err);
+      }
+      return;
+    }
 
     conn.query(sql, values, function () {
       conn.release();


### PR DESCRIPTION
Add a check in Pool.prototype.query to see if the callback is a function, to allow calling it with no callback specified (i.e. for UPDATE/INSERT type queries)
