### PR TITLE
Allow calling release on connection removed from pool

### DIFF
--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -16,6 +16,10 @@ function PoolConnection(pool, options) {
 }
 
 PoolConnection.prototype.release = function () {
+  if (!this._pool || this._pool._closed) {
+    return;
+  }
+
   return this._pool.releaseConnection(this);
 };
 

--- a/test/integration/pool/test-destroy-connection.js
+++ b/test/integration/pool/test-destroy-connection.js
@@ -11,5 +11,7 @@ pool.getConnection(function(err, connection) {
   assert.ok(pool._allConnections.length == 0);
   assert.ok(!connection._pool);
 
+  assert.doesNotThrow(function () { connection.release(); });
+
   pool.end();
 });


### PR DESCRIPTION
This adds a guard on `PoolConnection.prototype.release` to do nothing when the connection is no longer in the pool. This allows code to unconditionally call `release` on connections like responsible code even when the connection encountered an error or ended and was thus removed from the pool already.

Fixes #589
