### PR TITLE
Fixes #560: Allow to specify source IP address for TCP connection.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -133,6 +133,7 @@ When establishing a connection, you can set the following options:
 * `host`: The hostname of the database you are connecting to. (Default:
   `localhost`)
 * `port`: The port number to connect to. (Default: `3306`)
+* `localAddress`: The source IP address to use for TCP connection. (Optional)
 * `socketPath`: The path to a unix domain socket to connect to. When used `host`
   and `port` are ignored.
 * `user`: The MySQL user to authenticate as.

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -51,9 +51,10 @@ Connection.prototype.connect = function(cb) {
   if (!this._connectCalled) {
     this._connectCalled = true;
 
+    // Connect either via a UNIX domain socket or a TCP socket.
     this._socket = (this.config.socketPath)
       ? Net.createConnection(this.config.socketPath)
-      : Net.createConnection(this.config.port, this.config.host);
+      : Net.createConnection(this.config);
 
     // Node v0.10+ Switch socket into "old mode" (Streams2)
     this._socket.on("data",function() {});

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -10,6 +10,7 @@ function ConnectionConfig(options) {
 
   this.host               = options.host || 'localhost';
   this.port               = options.port || 3306;
+  this.localAddress       = options.localAddress;
   this.socketPath         = options.socketPath;
   this.user               = options.user || undefined;
   this.password           = options.password || undefined;


### PR DESCRIPTION
The `net.createConnection()` method supports giving a `localAddress` in the `options` argument; simply adding and forwarding this parameter.
