### PR TITLE
Use stream to handle local file.

### DIFF
--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -1,7 +1,6 @@
 var Parser       = require('./Parser');
 var Sequences    = require('./sequences');
 var Packets      = require('./packets');
-var Auth         = require('./Auth');
 var Stream       = require('stream').Stream;
 var Util         = require('util');
 var PacketWriter = require('./PacketWriter');
@@ -79,10 +78,20 @@ Protocol.prototype.end = function() {
 
 Protocol.prototype.pause = function() {
   this._parser.pause();
+  // Since there is a file stream in query, we must transmit pause/resume event to current sequence.
+  var seq = this._queue[0];
+  if (seq && seq.emit) {
+    seq.emit('pause');
+  }
 };
 
 Protocol.prototype.resume = function() {
   this._parser.resume();
+  // Since there is a file stream in query, we must transmit pause/resume event to current sequence.
+  var seq = this._queue[0];
+  if (seq && seq.emit) {
+    seq.emit('resume');
+  }
 };
 
 Protocol.prototype._enqueue = function(sequence) {

--- a/lib/protocol/sequences/Query.js
+++ b/lib/protocol/sequences/Query.js
@@ -155,13 +155,31 @@ Query.prototype['RowDataPacket'] = function(packet, parser, connection) {
 
 Query.prototype._sendLocalDataFile = function(path) {
   var self = this;
-  fs.readFile(path, 'utf-8', function(err, data) {
-    if (err) {
-      self._loadError = err;
-    } else {
-      self.emit('packet', new Packets.LocalDataFilePacket(data));
-    }
+  var localStream = fs.createReadStream(path, {
+    'flag': 'r',
+    'encoding': null,
+    'autoClose': true
+  });
 
+
+  this.on('pause', function () {
+    localStream.pause();
+  });
+
+  this.on('resume', function () {
+    localStream.resume();
+  });
+
+  localStream.on('data', function (data) {
+    self.emit('packet', new Packets.LocalDataFilePacket(data));
+  });
+
+  localStream.on('error', function (err) {
+    self._loadError = err;
+    localStream.emit('end');
+  });
+
+  localStream.on('end', function () {
     self.emit('packet', new Packets.EmptyPacket());
   });
 };
@@ -172,7 +190,7 @@ Query.prototype.stream = function(options) {
 
   options = options || {};
   options.objectMode = true;
-  stream = new Readable(options),
+  stream = new Readable(options);
 
   stream._read = function() {
     self._connection.resume();


### PR DESCRIPTION
If we use `LOAD DATA LOCAL INFILE` with a large file, current implementation will load the full content into memory and send in one large packet, which waste memory and worsen network load.
We should use file stream provided by node.js and divide the file content into small packets.
