### PR TITLE
Small optimization for parseUnsignedNumber

### DIFF
--- a/lib/protocol/Parser.js
+++ b/lib/protocol/Parser.js
@@ -112,16 +112,17 @@ Parser.prototype.peak = function() {
 };
 
 Parser.prototype.parseUnsignedNumber = function(bytes) {
-  var bytesRead = 0;
-  var value     = 0;
+  var offset = this._offset + bytes - 1;
+  var value  = 0;
 
-  while (bytesRead < bytes) {
-    var byte = this._buffer[this._offset++];
+  while (offset >= this._offset) {
+    value <<= 8;
+    value += this._buffer[offset];
 
-    value += byte * Math.pow(256, bytesRead);
-
-    bytesRead++;
+    offset--;
   }
+
+  this._offset += bytes;
 
   return value;
 };


### PR DESCRIPTION
This implements a small optimization for the `parseUnsignedNumber` method in the parser. This method is called multiple times for parsing almost all packets, making a gain here seem like it would be pretty nice. Checking out [a simple test on jsperf](http://jsperf.com/parse-uint) it seems like it would make this method about 3x faster than what it is now. I cannot say if this actually has any real-world performance impacts yet, though.
