### PR TITLE
Fix call site when using Pool.prototype.query

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -127,14 +127,23 @@ Pool.prototype.query = function (sql, values, cb) {
     cb = values;
     values = null;
   }
-  
+
+  var connection;
+  var query = Connection.createQuery(sql, values, function (err, rows, fields) {
+    connection.release();
+    cb.apply(this, arguments);
+  });
+
+  if (this.config.connectionConfig.trace) {
+    // Long stack trace support
+    query._callSite = new Error;
+  }
+
   this.getConnection(function (err, conn) {
     if (err) return cb(err);
 
-    conn.query(sql, values, function (err, rows, fields) {
-      conn.release();
-      cb.apply(this, arguments);
-    });
+    connection = conn;
+    conn.query(query);
   });
 };
 

--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -107,7 +107,7 @@ Protocol.prototype._enqueue = function(sequence) {
 
   if (this._config.trace) {
     // Long stack trace support
-    sequence._callSite = new Error;
+    sequence._callSite = sequence._callSite || new Error;
   }
 
   this._queue.push(sequence);

--- a/test/integration/pool/test-long-stack-traces.js
+++ b/test/integration/pool/test-long-stack-traces.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({connectionLimit: 1});
+
+var err;
+pool.getConnection(function(_err, conn) {
+  if (_err) throw _err;
+  pool.query('invalid sql', function(_err) {
+    err = _err;
+    pool.end();
+  });
+  process.nextTick(function() {
+    conn.release();
+  });
+});
+
+process.on('exit', function() {
+  assert.ok(err.stack.indexOf(__filename) > 0);
+});


### PR DESCRIPTION
This fixes the call site for long stack traces when using the `query` method on a pool object. Before the stack trace would only lead up to inside the `getConnection` method instead of the library caller. This results in the following change:

``` javascript
var mysql = require('mysql');
var pool = mysql.createPool(...);

pool.query('ERROR', function (err, rows) { // 1
  if (err) throw err;
  // The stack trace now includes the line marked 1
  // Prior to this, the stack trace included nothing from this file
});
```
