### PR TITLE
crypto.createHash fix for node.js < 11

### DIFF
--- a/lib/protocol/Auth.js
+++ b/lib/protocol/Auth.js
@@ -2,12 +2,23 @@ var Buffer = require('buffer').Buffer;
 var Crypto = require('crypto');
 var Auth   = exports;
 
-function sha1(msg) {
-  var hash = Crypto.createHash('sha1');
-  hash.update(msg);
-  // hash.digest() does not output buffers yet
-  return hash.digest('binary');
-};
+var sha1;
+if (Number(process.version.match(/^v\d+\.(\d+)/)[1]) >= 10){
+  sha1 = function(msg) {
+    var hash = Crypto.createHash('sha1');
+    hash.setEncoding('binary');
+    hash.write(msg);
+    hash.end();
+    return hash.read();
+  }
+} else {
+  sha1 = function(msg) {
+    var hash = Crypto.createHash('sha1');
+    hash.update(msg);
+    // hash.digest() does not output buffers yet
+    return hash.digest('binary');
+  }
+}
 Auth.sha1 = sha1;
 
 function xor(a, b) {


### PR DESCRIPTION
This PR will update the `sha1()` function @ [lib/protocol/Auth.js](https://github.com/felixge/node-mysql/blob/master/lib/protocol/Auth.js#L5) to update the `crypto.createHash` function to use the `.write()` & `.end()` functions vs. the depreciated `.update()` & `.digest()` methods when working with node.js < v0.10.*

I tried finding the exact version which removes the `.update()` & `.digest()` functions and through my tests I could only determine it to be between `v0.9.*` & `v0.10.*`.
