### PR TITLE
Do not console.warn non-sense Error

### DIFF
--- a/lib/PoolCluster.js
+++ b/lib/PoolCluster.js
@@ -150,7 +150,8 @@ PoolCluster.prototype._getConnection = function(node, cb) {
       self._increaseErrorCount(node);
       
       if (self._canRetry) {
-        console.warn('[Error] PoolCluster : ' + err);        
+        err.pool = node.pool;
+        self.emit('warn', err);
         return cb(null, 'retry');
       } else {
         return cb(err);


### PR DESCRIPTION
`console.warn` in lib/PoolCluster.js is useless, for it does not tell me which node is suffering error and the details of the node.
Instead,  we should emit a "warn" event with pool, which is much more useful. Anyone who concerns about these messages can handle it themselves.
