### PR TITLE
Auth: createHash fix < v0.11.5

### DIFF
--- a/lib/protocol/Auth.js
+++ b/lib/protocol/Auth.js
@@ -3,10 +3,9 @@ var Crypto = require('crypto');
 var Auth   = exports;
 
 var sha1;
-if (Number(process.version.match(/^v\d+\.(\d+)/)[1]) >= 10){
+if (typeof Crypto.createHash.write == 'function') {
   sha1 = function(msg) {
     var hash = Crypto.createHash('sha1');
-    hash.setEncoding('binary');
     hash.write(msg);
     hash.end();
     return hash.read();


### PR DESCRIPTION
@dougwilson Here is a grid of tests I just ran... you are correct < `v0.10.5` & `v0.11.0` - `v0.11.4` are a problem. With that in mind this pr will expand the check to accommodate the PATCH and only apply the newer hash functions for anything > `v0.11.5`.

Ref: [#735](https://github.com/felixge/node-mysql/pull/735)

| version | results |
| --- | --- |
| v0.10.4 | failed |
| v0.10.5 | pass |
| v0.10.6 | pass |
| v0.10.7 | pass |
| v0.10.8 | pass |
| ... | ... |
| v0.10.25 | pass |
| v0.10.26 | pass |
| ... | ... |
| v0.11.0 | failed |
| v0.11.1 | failed |
| v0.11.2 | failed |
| v0.11.3 | pass |
| v0.11.4 | failed (compile errors) |
| v0.11.5 | pass |
