### PR TITLE
Fix Issue #792: Escaping an array of query identifiers doesn't use parentheses...

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -2,9 +2,9 @@ var SqlString = exports;
 
 SqlString.escapeId = function (val, forbidQualified) {
   if (Array.isArray(val)) {
-    return val.map(function(v) {
+    return '(' + val.map(function(v) {
       return SqlString.escapeId(v, forbidQualified);
-    }).join(', ');
+    }).join(', ') + ')';
   }
 
   if (forbidQualified) {


### PR DESCRIPTION
Here is a quick fix for issue #792.

When you supply an array of identifiers to be escaped (useful for multi-insert queries) the escaped results should be surrounded with parentheses.
