### PR TITLE
add Warning Full Connection Pool

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -30,7 +30,9 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this._freeConnections.length > 0) {
     connection = this._freeConnections.shift();
-
+    if(this.config.warningFullConnectionPool) {
+        connection._stack = new Error().stack;
+    }
     return process.nextTick(function(){
       cb(null, connection);
     });
@@ -38,6 +40,9 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
     connection = new PoolConnection(this, { config: this.config.connectionConfig });
+    if(this.config.warningFullConnectionPool) {
+        connection._stack = new Error().stack;
+    }
 
     this._allConnections.push(connection);
 
@@ -62,6 +67,13 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this.config.queueLimit && this._connectionQueue.length >= this.config.queueLimit) {
     return cb(new Error('Queue limit reached.'));
+  }
+
+  if(this.config.warningFullConnectionPool) {
+    for(var i in this._allConnections) {
+      var conn = this._allConnections[i];
+      console.warn("Full Mysql Connection Pool - lastConnectionData\nstack : %s \nquery : %s\nquery stack : %s", conn._stack, conn._lastQuery, conn._lastCallStack);
+    }
   }
 
   if (cb && process.domain)

--- a/lib/PoolConfig.js
+++ b/lib/PoolConfig.js
@@ -13,4 +13,7 @@ function PoolConfig(options) {
   this.queueLimit         = (options.queueLimit === undefined)
     ? 0
     : Number(options.queueLimit);
+  this.warningFullConnectionPool = (options.warningFullConnectionPool === undefined)
+    ? false
+    : Boolean(options.warningFullConnectionPool);
 }

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -50,3 +50,12 @@ PoolConnection.prototype._removeFromPool = function(connection) {
 
   pool._removeConnection(this);
 };
+
+PoolConnection.prototype.query = function(sql, values, cb) {
+  if(this._pool.config.warningFullConnectionPool) {
+    this._lastQuery = sql;
+    this._lastCallStack = new Error().stack;
+  }
+  return PoolConnection.super_.prototype.query.apply(this, [sql, values, cb]);
+};
+


### PR DESCRIPTION
Sometimes 'pool' is used without calling 'release', which is hard to detect.
By adding 'warningFullConnectionPool', developer can find unreleased pool with ease.
