### PR TITLE
Creating a shallow copy of the config object for every connection created by the pool

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -35,7 +35,7 @@ Pool.prototype.getConnection = function (cb) {
   }
 
   if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
-    connection = new PoolConnection(this, { config: this.config.connectionConfig });
+    connection = new PoolConnection(this, { config: Util._extend({}, this.config.connectionConfig) });
 
     this._allConnections.push(connection);
 

--- a/test/integration/pool/test-pool-change-user.js
+++ b/test/integration/pool/test-pool-change-user.js
@@ -1,0 +1,29 @@
+var common     = require('../../common');
+var assert     = require('assert');
+var pool       = common.createPool();
+var connection = common.createConnection();
+
+var newDatabase = common.testDatabase + '2';
+
+connection.query('CREATE DATABASE IF NOT EXISTS ' + newDatabase, function(err) {
+  if (err && err.code !== 'ER_DB_CREATE_EXISTS') throw err;
+  connection.end();
+});
+
+pool.getConnection(function (err, firstConn) {
+  if (err) throw err;
+
+  firstConn.changeUser({ database: newDatabase }, function (err) {
+    if (err) throw err;
+
+    pool.getConnection(function (err, secondConn) {
+      if (err) throw err;
+
+      assert.equal(firstConn.config.database, newDatabase);
+      assert.notEqual(secondConn.config.database, newDatabase);
+
+      pool.end();
+    });
+  });
+
+});


### PR DESCRIPTION
This prevents changing one connection's config object when other connections changes their config object (by changing its user, for example).

I had a problem with this because I'm using the connection's config.database property to know when to switch users.
