### PR TITLE
call the callback when getting a connection from the pool fails

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -82,9 +82,12 @@ Pool.prototype.acquireConnection = function acquireConnection(connection, cb) {
       return;
     }
 
+	// Still here, connection failed. Lets call the callback!
+	cb('connection closed', null);
+
     connection.destroy();
     pool._connectionQueue.unshift(cb);
-    pool._removeConnection(connection);
+    pool._removeConnection(connection); 
   });
 };
 


### PR DESCRIPTION
When getting a connection from a pool fails the ping test, the callback is never called. This fixes it.
