### PR TITLE
Add support for column aliases

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -11,6 +11,14 @@ SqlString.escapeId = function escapeId(val, forbidQualified) {
     return sql;
   }
 
+  if( !!val && typeof val === 'object' ) {
+    return Object.keys(val).map(function(orig) {
+      return SqlString.escapeId(orig, forbidQualified) 
+             +  ' AS '
+             + SqlString.escapeId(val[orig], forbidQualified)
+    }).join(', ');
+  }
+
   if (forbidQualified) {
     return '`' + val.replace(/`/g, '``') + '`';
   }

--- a/test/unit/protocol/test-SqlString.js
+++ b/test/unit/protocol/test-SqlString.js
@@ -25,7 +25,11 @@ test('SqlString.escapeId', {
 
   'nested arrays are flattened': function() {
     assert.equal(SqlString.escapeId(['a', ['b', ['t.c']]]), "`a`, `b`, `t`.`c`");
-  }
+  },
+
+  'objects are turned into column aliases': function() {
+    assert.equal(SqlString.escapeId(['a', {'b':'c','d':'e'}]), "`a`, `b` AS `c`, `d` AS `e`");
+  },
 });
 
 test('SqlString.escape', {


### PR DESCRIPTION
I didn't see support for column aliases, so I updated escapeId to see objects in the column list as the signal to alias. The key of the object is the original column and the value the alias.