### PR TITLE
Performance improvements for formatting in SqlString (caching)

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -11,6 +11,7 @@ var charsMap   = {
   '\'': '\\\'',
   '\\': '\\\\'
 };
+var formatters = {};
 
 SqlString.escapeId = function escapeId(val, forbidQualified) {
   if (Array.isArray(val)) {
@@ -72,20 +73,20 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
 };
 
 SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
-  values = values == null ? [] : [].concat(values);
+  if (values == null) {
+    return sql;
+  }
 
-  var index = 0;
-  return sql.replace(/\?\??/g, function(match) {
-    if (index === values.length) {
-      return match;
-    }
+  if (!(values instanceof Array)) {
+    values = [values];
+  }
 
-    var value = values[index++];
+  var formatter = formatters[sql];
+  if (!formatter) {
+    formatter = formatters[sql] = buildFormatter(sql);
+  }
 
-    return match === '??'
-      ? SqlString.escapeId(value)
-      : SqlString.escape(value, stringifyObjects, timeZone);
-  });
+  return formatter(SqlString, values, stringifyObjects, timeZone);
 };
 
 SqlString.dateToString = function dateToString(date, timeZone) {
@@ -148,6 +149,33 @@ SqlString.objectToValues = function objectToValues(object, timeZone) {
 
   return sql;
 };
+
+function buildFormatter(sql) {
+  var valuesIndex = 0;
+
+  function escapingReplacer(match) {
+    if (match.length === 1 && match !== '?') {
+      return charsMap[match];
+    }
+
+    var replacement = '(' + valuesIndex + ' < len ? ' + (
+      match === '?'
+        ? 's.escape(v[' + valuesIndex + '],so,tz)'
+        : 's.escapeId(v[' + valuesIndex + '])'
+    ) + ' : "' + match + '")';
+
+    ++valuesIndex;
+
+    return '" + ' + replacement + ' + "';
+  }
+
+  return new Function(
+    's,v,so,tz',
+    '"use strict";\n' +
+    'var len = v.length;\n' +
+    'return "' + sql.replace(/\?\??|["\r\n]/g, escapingReplacer) + '";'
+  );
+}
 
 function escapeString(val) {
   var chunkIndex = charsRegex.lastIndex = 0;


### PR DESCRIPTION
Improve performance by:
- Returning early if there are no values to use for formatting
- Not copying the `values` argument if it is already an Array
- Compiling and caching an optimized formatting function for each unique query string
#### Benchmark Results

| Query | Before (ops/sec) | This PR (ops/sec) | Speedup (`PR/before`) |
| --- | --- | --- | --- |
| no values | 1,950,229 | 52,944,361 | 27 |
| 1) simple query | 842,548 | 3,603,032 | 4.3 |
| 2) more values | 700,379 | 2,848,857 | 4.1 |
| 3) a lot of values | 419,132 | 950,663 | 2.3 |
| 4) long query string, few values | 748,445 | 3,538,848 | 4.7 |

See [this gist](https://gist.github.com/nwoltman/7de8311bb69b56bb0002265ad0e5df97) for the code.

The technique for compiling the formatting function was explained by [Felix](https://github.com/felixge) in his talk/post [Faster than C?](https://github.com/felixge/faster-than-c#examples). It's the same technique that [EJS](https://www.npmjs.com/package/ejs) is built on. Basically, this is how it works:

``` js
buildFormatter('SELECT * FROM `user` WHERE ?? = ?');
// returns a function that looks like this:
function formatter(SqlString, values, stringifyObjects, timeZone) {
  "use strict";
  var len = values.length;
  return "SELECT * FROM `user` WHERE " + (0 < len ? SqlString.escapeId(values[0]) : "??") + " = " + (1 < len ? SqlString.escape(values[1], stringifyObjects, timeZone) : "?") + "";
}
```

The `(index < values.length ? escape(values[index]) : 'placeholder')` is needed in case there are less values provided than placeholders.
