### PR TITLE
Add sql to error messages.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1074,6 +1074,10 @@ object. Additionally they typically come with two extra properties:
 [Error]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
 [MySQL server error]: http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
 
+In addition, MySQL server errors will have an `err.sql` property that contains the SQL
+of the failed query. This can we useful when using a higher level interface like an
+ORM that is generating your queries for you.
+
 Fatal errors are propagated to *all* pending callbacks. In the example below, a
 fatal error is triggered by trying to connect to an invalid port. Therefore the
 error object is propagated to both pending callbacks:

--- a/lib/protocol/sequences/Sequence.js
+++ b/lib/protocol/sequences/Sequence.js
@@ -52,6 +52,7 @@ Sequence.prototype._packetToError = function(packet) {
   err.code = code;
   err.errno = packet.errno;
   err.sqlState = packet.sqlState;
+  err.sql = this.sql;
 
   return err;
 };

--- a/test/unit/query/test-error-event.js
+++ b/test/unit/query/test-error-event.js
@@ -7,11 +7,13 @@ var server = common.createFakeServer();
 server.listen(common.fakeServerPort, function (err) {
   assert.ifError(err);
 
-  var query = connection.query('INVALID SQL');
+  var sql = 'INVALID SQL';
+  var query = connection.query(sql);
 
   query.on('error', function (err) {
     assert.ok(err, 'got error');
     assert.equal(err.code, 'ER_PARSE_ERROR');
+    assert.equal(err.sql, sql);
     assert.ok(!err.fatal);
     connection.destroy();
     server.destroy();


### PR DESCRIPTION
We've been using this change on our project and it has greatly improved our debugging. We're using it in Loopback and we would often get errors straight from the mysql package, but not have any idea which query generated them.

The change is a little hacked in as is, but I'm open to modifying it as needed to get merged.
