### PR TITLE
fix type error spelling in documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -200,7 +200,7 @@ When establishing a connection, you can set the following options:
 * `connectTimeout`: The milliseconds before a timeout occurs during the initial connection
   to the MySQL server. (Default: `10000`)
 * `stringifyObjects`: Stringify objects instead of converting to values. See
-issue [#501](https://github.com/mysqljs/mysql/issues/501). (Default: `'false'`)
+issue [#501](https://github.com/mysqljs/mysql/issues/501). (Default: `false`)
 * `insecureAuth`: Allow connecting to MySQL instances that ask for the old
   (insecure) authentication method. (Default: `false`)
 * `typeCast`: Determines if column values should be converted to native


### PR DESCRIPTION
@Simran-B pointed this out here https://github.com/tellnes/node-mysql/commit/dd921c3dac1c5dc1afbc2149be6d10665973b9f2#commitcomment-18778650