### PR TITLE
Typo fix in error message

### DIFF
--- a/lib/protocol/sequences/Handshake.js
+++ b/lib/protocol/sequences/Handshake.js
@@ -40,7 +40,7 @@ Handshake.prototype['HandshakeInitializationPacket'] = function(packet) {
 
   if (this._config.ssl) {
     if (!serverSSLSupport) {
-      var err = new Error('Server does not support secure connnection');
+      var err = new Error('Server does not support secure connection');
 
       err.code = 'HANDSHAKE_NO_SSL_SUPPORT';
       err.fatal = true;


### PR DESCRIPTION
Extra "n" in "Server does not support secure connnection" error.