### PR TITLE
Readme.md: adds section about query logging

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1327,6 +1327,20 @@ will have:
 * As much debugging output and information about your environment (mysql
   version, node version, os, etc.) as you can gather.
 
+### Logging All Queries from a Connection Pool
+
+To log all the queries from a connection pool, bind to the `enqueue` event on each connection and check for the `mysql` property on the `sequence` object:
+
+```js
+pool.on('connection', function (connection) {
+  connection.on('enqueue', function (sequence) {
+    if (sequence && sequence.sql) {
+      console.log(sequence.sql);
+    }
+  });
+});
+```
+
 ## Contributing
 
 This project welcomes contributions from the community. Contributions are


### PR DESCRIPTION
First off, I wanted to say "thank you" for creating and maintaining this great module!

Recently, I ran into a use case where I wanted to log all the raw queries being made by a connection pool.

I had to dig around the Issues tab a bit until I landed upon [this](https://github.com/mysqljs/mysql/issues/1272#issuecomment-170144701). It was close to the solution I needed (I dug into the source code and saw that the `Sequence` object was not being bound to the main export Object, so ended up removing the `mysql.Sequences.Query` line and it worked like a charm).

I think having this little snippet in the README itself would help future users quickly find out how to do this. I figured it made most sense as a sub-section within the `Debugging and reporting problems` section.

Please let me know if should adjust anything or if adding this to the docs does not make sense. 

Thanks!
