### PR TITLE
Improved the logic of Pool's changeUser.

### DIFF
--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -57,7 +57,7 @@ function ConnectionConfig(options) {
 
   // Set the client flags
   var defaultFlags = ConnectionConfig.getDefaultFlags(options);
-  this.clientFlags = ConnectionConfig.mergeFlags(defaultFlags, options.flags);
+  this.clientFlags = ConnectionConfig.mergeFlags(defaultFlags, this.flags);
 }
 
 ConnectionConfig.mergeFlags = function mergeFlags(defaultFlags, userFlags) {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -19,8 +19,7 @@ function Pool(options) {
   this._closed               = false;
 }
 
-Pool.prototype.getConnection = function (cb) {
-
+Pool.prototype.getConnection = function getConnection(cb) {
   if (this._closed) {
     var err = new Error('Pool is closed.');
     err.code = 'POOL_CLOSED';
@@ -39,13 +38,15 @@ Pool.prototype.getConnection = function (cb) {
     return;
   }
 
-  if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
-    connection = new PoolConnection(this, { config: this.config.newConnectionConfig() });
+  var config = this.config;
+
+  if (config.connectionLimit === 0 || this._allConnections.length < config.connectionLimit) {
+    connection = new PoolConnection(this, { config: config.newConnectionConfig() });
 
     this._acquiringConnections.push(connection);
     this._allConnections.push(connection);
 
-    connection.connect({timeout: this.config.acquireTimeout}, function onConnect(err) {
+    connection.connect({timeout: config.acquireTimeout}, function onConnect(err) {
       spliceConnection(pool._acquiringConnections, connection);
 
       if (pool._closed) {
@@ -65,7 +66,7 @@ Pool.prototype.getConnection = function (cb) {
     return;
   }
 
-  if (!this.config.waitForConnections) {
+  if (!config.waitForConnections) {
     process.nextTick(function(){
       var err = new Error('No connections available.');
       err.code = 'POOL_CONNLIMIT';
@@ -102,6 +103,7 @@ Pool.prototype.acquireConnection = function acquireConnection(connection, cb) {
     }
 
     if (changeUser) {
+      connection.config.changedUser = false;
       pool.emit('connection', connection);
     }
 
@@ -240,10 +242,11 @@ Pool.prototype._needsChangeUser = function _needsChangeUser(connection) {
   var poolConfig = this.config.connectionConfig;
 
   // check if changeUser values are different
-  return connConfig.user !== poolConfig.user
+  return connConfig.changedUser
+    && (connConfig.user !== poolConfig.user
     || connConfig.database !== poolConfig.database
     || connConfig.password !== poolConfig.password
-    || connConfig.charsetNumber !== poolConfig.charsetNumber;
+    || connConfig.charsetNumber !== poolConfig.charsetNumber);
 };
 
 Pool.prototype._purgeConnection = function _purgeConnection(connection, callback) {

--- a/lib/protocol/sequences/ChangeUser.js
+++ b/lib/protocol/sequences/ChangeUser.js
@@ -26,10 +26,12 @@ ChangeUser.prototype.start = function(handshakeInitializationPacket) {
     charsetNumber : this._charsetNumber
   });
 
-  this._currentConfig.user          = this._user;
-  this._currentConfig.password      = this._password;
-  this._currentConfig.database      = this._database;
-  this._currentConfig.charsetNumber = this._charsetNumber;
+  var currentConfig = this._currentConfig;
+  currentConfig.user          = this._user;
+  currentConfig.password      = this._password;
+  currentConfig.database      = this._database;
+  currentConfig.charsetNumber = this._charsetNumber;
+  currentConfig.changedUser   = true;
 
   this.emit('packet', packet);
 };

--- a/test/integration/connection/test-change-user-charset.js
+++ b/test/integration/connection/test-change-user-charset.js
@@ -1,0 +1,18 @@
+var assert = require('assert');
+var common = require('../../common');
+
+common.getTestConnection(function (err, connection) {
+  assert.ifError(err);
+
+  // should change charset
+  connection.changeUser({charset:'KOI8R_GENERAL_CI'}, function (err) {
+    assert.ifError(err);
+
+    connection.query('SHOW VARIABLES LIKE \'character_set_client\'', function (err, result) {
+      assert.ifError(err);
+      assert.strictEqual(result[0]['Value'], 'koi8r');
+
+      connection.destroy();
+    });
+  });
+});

--- a/test/integration/connection/test-format.js
+++ b/test/integration/connection/test-format.js
@@ -1,0 +1,14 @@
+var path   = require('path');
+var assert = require('assert');
+var common = require('../../common');
+var lib    = require(path.resolve(common.lib, '../index'));
+
+assert.equal(
+	lib.format('SELECT * FROM ?? WHERE ?? = ?', [ 'table', 'property', 123 ]),
+	'SELECT * FROM `table` WHERE `property` = 123'
+);
+
+assert.equal(
+	lib.format('INSERT INTO ?? SET ?', [ 'table', { property: 123 } ]),
+	'INSERT INTO `table` SET `property` = 123'
+);

--- a/test/integration/connection/test-query.js
+++ b/test/integration/connection/test-query.js
@@ -8,6 +8,13 @@ common.getTestConnection(function (err, connection) {
     assert.ifError(err);
     assert.deepEqual(rows, [{1: 1}]);
     assert.equal(fields[0].name, '1');
-    connection.end(assert.ifError);
+
+    // this is a coverage test, it shuold perform exactly as the previous one
+    connection.query({ sql: 'SELECT ?' }, [ 1 ], function (err, rows, fields) {
+      assert.ifError(err);
+      assert.deepEqual(rows, [{1: 1}]);
+      assert.equal(fields[0].name, '1');
+      connection.end(assert.ifError);
+    });
   });
 });

--- a/test/integration/connection/test-types.js
+++ b/test/integration/connection/test-types.js
@@ -1,0 +1,11 @@
+var path   = require('path');
+var assert = require('assert');
+var common = require('../../common');
+var lib    = require(path.resolve(common.lib, '../index'));
+var types  = require(path.resolve(common.lib, 'protocol/constants/types'));
+
+assert.equal(typeof lib.Types, "object");
+
+for (var k in types) {
+	assert.equal(lib.Types[k], types[k]);
+}

--- a/test/unit/connection/test-change-user.js
+++ b/test/unit/connection/test-change-user.js
@@ -21,8 +21,18 @@ server.listen(common.fakeServerPort, function(err) {
         assert.ifError(err);
         assert.strictEqual(result[0]['CURRENT_USER()'], 'user_2@localhost');
 
-        connection.destroy();
-        server.destroy();
+        // should keep current user
+        connection.changeUser(function (err) {
+          assert.ifError(err);
+
+          connection.query('SELECT CURRENT_USER()', function (err, result) {
+            assert.ifError(err);
+            assert.strictEqual(result[0]['CURRENT_USER()'], 'user_2@localhost');
+
+            connection.destroy();
+            server.destroy();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
I don't think `connection.changeUser()` would be used frequently in the real world.
But, An unnecessary routine for this is tested whenever `pool.getConnection()` is called.

This PR is aimed at reduction in this complexity. As a result, `pool.getConnection` works 3~4 times faster.

In addition, a small bug was fixed. (lib/ConnectionConfig.js)
