### PR TITLE
Fix Readme.md (Performing Queries)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -587,7 +587,7 @@ connection.query({
 ```
 
 Note that a combination of the second and third forms can be used where the
-placeholder values are passes as an argument and not in the options object.
+placeholder values are passed as an argument and not in the options object.
 The `values` argument will override the `values` in the option object.
 
 ```js

--- a/test/integration/connection/test-change-user-charset.js
+++ b/test/integration/connection/test-change-user-charset.js
@@ -1,0 +1,18 @@
+var assert = require('assert');
+var common = require('../../common');
+
+common.getTestConnection(function (err, connection) {
+  assert.ifError(err);
+
+  // should change charset
+  connection.changeUser({charset:'KOI8R_GENERAL_CI'}, function (err) {
+    assert.ifError(err);
+
+    connection.query('SHOW VARIABLES LIKE \'character_set_client\'', function (err, result) {
+      assert.ifError(err);
+      assert.strictEqual(result[0]['Value'], 'koi8r');
+
+      connection.destroy();
+    });
+  });
+});

--- a/test/integration/connection/test-format.js
+++ b/test/integration/connection/test-format.js
@@ -1,0 +1,14 @@
+var path   = require('path');
+var assert = require('assert');
+var common = require('../../common');
+var lib    = require(path.resolve(common.lib, '../index'));
+
+assert.equal(
+	lib.format('SELECT * FROM ?? WHERE ?? = ?', [ 'table', 'property', 123 ]),
+	'SELECT * FROM `table` WHERE `property` = 123'
+);
+
+assert.equal(
+	lib.format('INSERT INTO ?? SET ?', [ 'table', { property: 123 } ]),
+	'INSERT INTO `table` SET `property` = 123'
+);

--- a/test/integration/connection/test-query.js
+++ b/test/integration/connection/test-query.js
@@ -8,6 +8,13 @@ common.getTestConnection(function (err, connection) {
     assert.ifError(err);
     assert.deepEqual(rows, [{1: 1}]);
     assert.equal(fields[0].name, '1');
-    connection.end(assert.ifError);
+
+    // this is a coverage test, it shuold perform exactly as the previous one
+    connection.query({ sql: 'SELECT ?' }, [ 1 ], function (err, rows, fields) {
+      assert.ifError(err);
+      assert.deepEqual(rows, [{1: 1}]);
+      assert.equal(fields[0].name, '1');
+      connection.end(assert.ifError);
+    });
   });
 });

--- a/test/integration/connection/test-types.js
+++ b/test/integration/connection/test-types.js
@@ -1,0 +1,11 @@
+var path   = require('path');
+var assert = require('assert');
+var common = require('../../common');
+var lib    = require(path.resolve(common.lib, '../index'));
+var types  = require(path.resolve(common.lib, 'protocol/constants/types'));
+
+assert.equal(typeof lib.Types, "object");
+
+for (var k in types) {
+	assert.equal(lib.Types[k], types[k]);
+}

--- a/test/unit/connection/test-change-user.js
+++ b/test/unit/connection/test-change-user.js
@@ -21,8 +21,18 @@ server.listen(common.fakeServerPort, function(err) {
         assert.ifError(err);
         assert.strictEqual(result[0]['CURRENT_USER()'], 'user_2@localhost');
 
-        connection.destroy();
-        server.destroy();
+        // should keep current user
+        connection.changeUser(function (err) {
+          assert.ifError(err);
+
+          connection.query('SELECT CURRENT_USER()', function (err, result) {
+            assert.ifError(err);
+            assert.strictEqual(result[0]['CURRENT_USER()'], 'user_2@localhost');
+
+            connection.destroy();
+            server.destroy();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Changed "values are _passes_ as an argument" to "values are _passed_ as an argument" in the "**Performing Queries**" section of the readme. 

This is a basic typo fix which also clarifies meaning. It is now more clear how passing values to queries works, whereas before the wording was confusing due to the typo.