### PR TITLE
Added the query execution time in query()'s callback.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -281,6 +281,26 @@ Connection.prototype.format = function(sql, values) {
   return SqlString.format(sql, values, this.config.stringifyObjects, this.config.timezone);
 };
 
+Connection.prototype.enableQueryTimeProfiling = function(callback) {
+  this._isQueryTimeProfilingMode = true;
+
+  if (callback) {
+    this.on('queryTimeProfiling', function(query) {
+      callback(query);
+    });
+  }
+};
+
+Connection.prototype.disableQueryTimeProfiling = function() {
+  this._isQueryTimeProfilingMode = false;
+
+  this.removeAllListeners('queryTimeProfiling');
+};
+
+Connection.prototype.isQueryTimeProfilingMode = function() {
+  return this._isQueryTimeProfilingMode || false;
+};
+
 if (tls.TLSSocket) {
   // 0.11+ environment
   Connection.prototype._startTLS = function _startTLS(onSecure) {

--- a/lib/protocol/sequences/Query.js
+++ b/lib/protocol/sequences/Query.js
@@ -26,6 +26,7 @@ function Query(options, callback) {
 }
 
 Query.prototype.start = function() {
+  this._saveQueryTime('request');
   this.emit('packet', new Packets.ComQueryPacket(this.sql));
 };
 
@@ -89,6 +90,8 @@ Query.prototype['ErrorPacket'] = function(packet) {
 };
 
 Query.prototype['ResultSetHeaderPacket'] = function(packet) {
+  this._saveQueryTime('first_response');
+
   if (packet.fieldCount === null) {
     this._sendLocalDataFile(packet.extra);
   } else {
@@ -103,8 +106,12 @@ Query.prototype['FieldPacket'] = function(packet) {
 Query.prototype['EofPacket'] = function(packet) {
   this._resultSet.eofPackets.push(packet);
 
-  if (this._resultSet.eofPackets.length === 1 && !this._callback) {
-    this.emit('fields', this._resultSet.fieldPackets, this._index);
+  if (this._resultSet.eofPackets.length === 1) {
+    this._saveQueryTime('fields');
+
+    if (!this._callback) {
+      this.emit('fields', this._resultSet.fieldPackets, this._index);
+    }
   }
 
   if (this._resultSet.eofPackets.length !== 2) {
@@ -126,6 +133,8 @@ Query.prototype._handleFinalResultPacket = function(packet) {
     return;
   }
 
+  this._saveQueryTime('end');
+
   var results = (this._results.length > 1)
     ? this._results
     : this._results[0];
@@ -138,6 +147,11 @@ Query.prototype._handleFinalResultPacket = function(packet) {
 };
 
 Query.prototype['RowDataPacket'] = function(packet, parser, connection) {
+  if (typeof this._hasRows === 'undefined') {
+    this._saveQueryTime('first_row');
+    this._hasRows = true;
+  }
+
   packet.parse(parser, this._resultSet.fieldPackets, this.typeCast, this.nestTables, connection);
 
   if (this._callback) {
@@ -213,4 +227,65 @@ Query.prototype.stream = function(options) {
   });
 
   return stream;
+};
+
+Query.prototype._saveQueryTime = function(tag) {
+  if (this._connection.isQueryTimeProfilingMode()) {
+    if (typeof this._queryTimeTimeline === 'undefined') {
+      this._queryTimeTimeline = {};
+    }
+
+    this._queryTimeTimeline[tag] = typeof process.hrtime === 'undefined' ? Date.now() : process.hrtime();
+
+    if (tag === 'end') {
+      this._queryTimeProfilingData = {
+        sql      : this.sql,
+        timeline : {
+          first_byte : this._getQueryTimeDiff(this._queryTimeTimeline.first_response, this._queryTimeTimeline.request),
+          fields     : this._getQueryTimeDiff(this._queryTimeTimeline.fields, this._queryTimeTimeline.first_response),
+          first_row  : this._getQueryTimeDiff(this._queryTimeTimeline.first_row, this._queryTimeTimeline.fields),
+          last_row   : this._getQueryTimeDiff(this._queryTimeTimeline.end, this._queryTimeTimeline.first_row)
+        }
+      };
+
+      var timeline = this._queryTimeProfilingData.timeline;
+      this._queryTimeProfilingData.total_time = (timeline.first_byte + timeline.fields + timeline.first_row + timeline.last_row).toFixed(9);
+
+      delete this._queryTimeTimeline;
+
+      this._connection.emit('queryTimeProfiling', this);
+    }
+  }
+};
+
+Query.prototype._getQueryTimeDiff = function(endTime, startTime) {
+  if (Array.isArray(endTime)) {
+    return (endTime[0] - startTime[0]) + (endTime[1] - startTime[1]) / 1e9;
+  } else {
+    return (endTime - startTime) / 1000;
+  }
+};
+
+Query.prototype.getQueryTimeProfiling = function() {
+  return this._queryTimeProfilingData;
+};
+
+Query.prototype.printQueryTimeProfiling = function() {
+  var data = this.getQueryTimeProfiling();
+  if (data === null) {
+    console.log("[!] There's no time information for this query.");
+    return;
+  }
+
+  console.log('===============================================================================');
+  console.log(data.sql);
+  console.log('-------------------------------------------------------------------------------');
+  console.log('- first_byte : %d sec.', data.timeline.first_byte);
+  console.log('- fields     : %d sec.', data.timeline.fields);
+  console.log('- first_row  : %d sec.', data.timeline.first_row);
+  console.log('- last_row   : %d sec.', data.timeline.last_row);
+  console.log();
+  console.log('# total time : %d sec.', data.total_time);
+  console.log('===============================================================================');
+  console.log();
 };


### PR DESCRIPTION
This is for #483 

Added to pass `queryTime` as the fourth argument of `query()`'s callback.

```js
connection.query('SELECT SLEEP(1)', function (error, results, fields, queryTime) {
    console.log(queryTime); // 1.005
});

```

I didn't use a new option to handle this. That's because it doesn't have the overhead that is serious enough to worry about.

I hope this helps.