### PR TITLE
add quering timing in ms as optional 4th parm to callback

### DIFF
--- a/lib/protocol/sequences/Query.js
+++ b/lib/protocol/sequences/Query.js
@@ -26,6 +26,7 @@ function Query(options, callback) {
 }
 
 Query.prototype.start = function() {
+  this.start_time = new Date().getTime()
   this.emit('packet', new Packets.ComQueryPacket(this.sql));
 };
 
@@ -136,7 +137,7 @@ Query.prototype._handleFinalResultPacket = function(packet) {
     ? this._fields
     : this._fields[0];
 
-  this.end(this._loadError, results, fields);
+  this.end(this._loadError, results, fields, new Date().getTime() - this.start_time);
 };
 
 Query.prototype['RowDataPacket'] = function(packet, parser, connection) {


### PR DESCRIPTION
I really need this kind of timing to optimize the performance of my sites. These trivial changes work for me, though I see they could include time in node itself between packets.