### PR TITLE
link to Ping section was missing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,7 @@
 - [Stored procedures](#stored-procedures)
 - [Joins with overlapping column names](#joins-with-overlapping-column-names)
 - [Transactions](#transactions)
+- [Ping](#ping)
 - [Timeouts](#timeouts)
 - [Error handling](#error-handling)
 - [Exception Safety](#exception-safety)


### PR DESCRIPTION
I was looking through the docs for how to use Ping and noticed that a link to the section was omitted. I decided to fix it as our first-ever pull request. If I did something wrong, _use lubricant_ please....