### PR TITLE
Support authentication switch request. Fixes #1396

### DIFF
--- a/lib/protocol/Parser.js
+++ b/lib/protocol/Parser.js
@@ -217,6 +217,11 @@ Parser.prototype.parseLengthCodedBuffer = function() {
   return this.parseBuffer(length);
 };
 
+Parser.prototype.parsePacketTerminatedBuffer = function() {
+  var length = this._packetEnd - this._offset;
+  return this.parseBuffer(length);
+};
+
 Parser.prototype.parseLengthCodedNumber = function parseLengthCodedNumber() {
   if (this._offset >= this._buffer.length) {
     var err    = new Error('Parser: read past end');

--- a/lib/protocol/packets/AuthenticationSwitchResponsePacket.js
+++ b/lib/protocol/packets/AuthenticationSwitchResponsePacket.js
@@ -1,0 +1,14 @@
+module.exports = AuthenticationSwitchResponsePacket;
+function AuthenticationSwitchResponsePacket(options) {
+  options = options || {};
+
+  this.scrambleBuff = options.scrambleBuff;
+}
+
+AuthenticationSwitchResponsePacket.prototype.parse = function(parser) {
+  this.scrambleBuff = parser.parsePacketTerminatedBuffer();
+};
+
+AuthenticationSwitchResponsePacket.prototype.write = function(writer) {
+  writer.writeBuffer(this.scrambleBuff);
+};

--- a/lib/protocol/packets/UseOldPasswordPacket.js
+++ b/lib/protocol/packets/UseOldPasswordPacket.js
@@ -2,13 +2,25 @@ module.exports = UseOldPasswordPacket;
 function UseOldPasswordPacket(options) {
   options = options || {};
 
-  this.firstByte = options.firstByte || 0xfe;
+  this.firstByte  = options.firstByte || 0xfe;
+  this.methodName = options.methodName;
+  this.pluginData = options.pluginData;
 }
 
 UseOldPasswordPacket.prototype.parse = function(parser) {
   this.firstByte = parser.parseUnsignedNumber(1);
+  if (!parser.reachedPacketEnd()) {
+    this.methodName = parser.parseNullTerminatedString();
+    this.pluginData = parser.parsePacketTerminatedBuffer();
+  }
 };
 
 UseOldPasswordPacket.prototype.write = function(writer) {
   writer.writeUnsignedNumber(1, this.firstByte);
+  if (this.methodName !== undefined) {
+    writer.writeNullTerminatedString(this.methodName);
+    if (this.pluginData !== undefined) {
+      writer.writeBuffer(this.pluginData);
+    }
+  }
 };

--- a/lib/protocol/packets/index.js
+++ b/lib/protocol/packets/index.js
@@ -1,3 +1,4 @@
+exports.AuthenticationSwitchResponsePacket = require('./AuthenticationSwitchResponsePacket');
 exports.ClientAuthenticationPacket = require('./ClientAuthenticationPacket');
 exports.ComChangeUserPacket = require('./ComChangeUserPacket');
 exports.ComPingPacket = require('./ComPingPacket');

--- a/lib/protocol/sequences/Handshake.js
+++ b/lib/protocol/sequences/Handshake.js
@@ -80,23 +80,46 @@ Handshake.prototype._sendCredentials = function() {
   }));
 };
 
-Handshake.prototype['UseOldPasswordPacket'] = function() {
-  if (!this._config.insecureAuth) {
+Handshake.prototype['UseOldPasswordPacket'] = function(packet) {
+  if (!packet || !packet.methodName || packet.methodName === 'mysql_old_password') {
+    if (!this._config.insecureAuth) {
+      var err = new Error(
+        'MySQL server is requesting the old and insecure pre-4.1 auth mechanism.' +
+        'Upgrade the user password or use the {insecureAuth: true} option.'
+      );
+
+      err.code = 'HANDSHAKE_INSECURE_AUTH';
+      err.fatal = true;
+
+      this.end(err);
+      return;
+    }
+
+    this.emit('packet', new Packets.OldPasswordPacket({
+      scrambleBuff: Auth.scramble323(packet.pluginData || this._handshakeInitializationPacket.scrambleBuff(), this._config.password)
+    }));
+  } else if (packet.methodName === 'mysql_native_password') {
+    // "auth plugin data" is documented as "string[EOF]", but MySQL Server will send a
+    // null-terminated byte array for mysql_native_password; we only need to hash with
+    // the first 20 bytes
+    var challenge = packet.pluginData;
+    if (challenge.length === 21 && challenge[20] === 0) {
+      challenge = challenge.slice(0, 20);
+    }
+
+    this.emit('packet', new Packets.AuthenticationSwitchResponsePacket({
+      scrambleBuff: Auth.token(this._config.password, challenge)
+    }));
+  } else {
     var err = new Error(
-      'MySQL server is requesting the old and insecure pre-4.1 auth mechanism.' +
-      'Upgrade the user password or use the {insecureAuth: true} option.'
+      'MySQL is requesting the ' + packet.methodName + ' authentication method, which is not supported.'
     );
 
-    err.code = 'HANDSHAKE_INSECURE_AUTH';
+    err.code = 'UNSUPPORTED_AUTH_METHOD';
     err.fatal = true;
 
     this.end(err);
-    return;
   }
-
-  this.emit('packet', new Packets.OldPasswordPacket({
-    scrambleBuff: Auth.scramble323(this._handshakeInitializationPacket.scrambleBuff(), this._config.password)
-  }));
 };
 
 Handshake.prototype['ErrorPacket'] = function(packet) {

--- a/test/unit/connection/test-force-auth-switch.js
+++ b/test/unit/connection/test-force-auth-switch.js
@@ -1,0 +1,34 @@
+var common     = require('../../common');
+var connection = common.createConnection({
+  port     : common.fakeServerPort,
+  password : 'authswitch'
+});
+var assert     = require('assert');
+
+var server = common.createFakeServer();
+
+var connected;
+server.listen(common.fakeServerPort, function(err) {
+  if (err) throw err;
+
+  connection.connect(function(err, result) {
+    if (err) throw err;
+
+    connected = result;
+
+    connection.destroy();
+    server.destroy();
+  });
+});
+
+server.on('connection', function(incomingConnection) {
+  incomingConnection.handshake({
+    user            : connection.config.user,
+    password        : connection.config.password,
+    forceAuthSwitch : true
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(connected.fieldCount, 0);
+});


### PR DESCRIPTION
The new code supports `mysql_native_password` and `mysql_old_password` as potential authentication methods (but still requires `insecureAuth: true` for the latter).

This fixes authentication against Azure Database for MySQL: #1729 

- [x] Add test for authentication method switch that "switches" to `mysql_native_password`
- [x] Maintain backwards compatibility
- [ ] Test whether MySQL server sends a `string[NUL]` value for `auth_method_data` although it's documented as `string[EOF]`.