### PR TITLE
Add stackCycle feature for decrease useless connections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -369,7 +369,7 @@ time one is needed.
 Connections are lazily created by the pool. If you configure the pool to allow
 up to 100 connections, but only ever use 5 simultaneously, only 5 connections
 will be made. Connections are also cycled round-robin style, with connections
-being taken from the top of the pool and returning to the bottom.
+being taken from the top of the pool and returning to the bottom. If you want to change cycle strategy, you can set `stackCycle` option in pool options.
 
 When a previous connection is retrieved from the pool, a ping packet is sent
 to the server to check if the connection is still good.
@@ -392,6 +392,7 @@ constructor. In addition to those options pools accept a few extras:
 * `queueLimit`: The maximum number of connection requests the pool will queue
   before returning an error from `getConnection`. If set to `0`, there is no
   limit to the number of queued connection requests. (Default: `0`)
+* `stackCycle`: Determines how the released connections rotates. If `true`, It's cycled stack style. If you need to disconnect a useless connection after suddenly an increase in connection, use the stack strategy. If `false`, It's cycled round-robin style. (Default: `false`)
 
 ## Pool events
 
@@ -1418,7 +1419,7 @@ and no password set for the `root` user, run:
 
 ```sh
 $ mysql -u root -e "CREATE DATABASE IF NOT EXISTS node_mysql_test"
-$ MYSQL_HOST=localhost MYSQL_PORT=3306 MYSQL_DATABASE=node_mysql_test MYSQL_USER=root MYSQL_PASSWORD= FILTER=integration npm test
+$ MYSQL_HOST=localhost MYSQL_PORT=3306 MYSQL_DATABASE=node_mysql_test MYSQL_USER=root MYSQL_PASSWORD=park FILTER=integration npm test
 ```
 
 ## Todo

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -137,8 +137,12 @@ Pool.prototype.releaseConnection = function releaseConnection(connection) {
       // this won't catch all double-release cases
       throw new Error('Connection already released');
     } else {
-      // add connection to end of free queue
-      this._freeConnections.push(connection);
+      if (this.config.stackCycle) {
+        this._freeConnections.unshift(connection);
+      } else {
+        // add connection to end of free queue
+        this._freeConnections.push(connection);
+      }
       this.emit('release', connection);
     }
   }

--- a/lib/PoolConfig.js
+++ b/lib/PoolConfig.js
@@ -20,6 +20,9 @@ function PoolConfig(options) {
   this.queueLimit         = (options.queueLimit === undefined)
     ? 0
     : Number(options.queueLimit);
+  this.stackCycle         = (options.stackCycle === undefined)
+    ? false
+    : Boolean(options.stackCycle);
 }
 
 PoolConfig.prototype.newConnectionConfig = function newConnectionConfig() {

--- a/test/unit/pool/test-connection-stack-cycle.js
+++ b/test/unit/pool/test-connection-stack-cycle.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({
+  connectionLimit : 2,
+  port            : common.fakeServerPort,
+  stackCycle      : true
+});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var releasedThreadId = null;
+  var releaseCount = 0;
+
+  pool.on('release', function (connection) {
+    releaseCount++;
+    releasedThreadId = connection.threadId;
+  });
+
+  pool.getConnection(function (err, firstConnection) {
+    assert.ifError(err);
+    assert.ok(firstConnection);
+
+    pool.getConnection(function (err, secondConnection) {
+      assert.ifError(err);
+      assert.ok(secondConnection);
+      firstConnection.release();
+      secondConnection.release();
+      assert.equal(releaseCount, 2);
+      assert.equal(releasedThreadId, secondConnection.threadId);
+
+      pool.getConnection(function (err, recycledConnection) {
+        assert.ifError(err);
+        assert.ok(recycledConnection);
+        assert.equal(recycledConnection.threadId, releasedThreadId);
+
+        pool.end(function (err) {
+          assert.ifError(err);
+          server.destroy();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
If you are using a connection pool and suddenly handle more traffic than usual, the size of the connection pool increases. And the increased connections will survive because of the wait_timeout setting. (It usually set as 10-30 seconds) Keeping unnecessary connections is not good for running multiple servers.

However, this problem can not be solved because the mysql module only supports round-robin styles. So I added a pool option called stackCycle.