### PR TITLE
Ping on release to sync wait_timeout behind MaxSclae

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -17,6 +17,13 @@ function Pool(options) {
   this._freeConnections      = [];
   this._connectionQueue      = [];
   this._closed               = false;
+  
+  // Sync wait_timeout on connections behind MaxScale
+  this.on('release', function(connection) {
+    if (connection && connection.ping && typeof connection.ping === 'function') {
+      connection.ping(function(){});
+    }
+  }); 
 }
 
 Pool.prototype.getConnection = function (cb) {


### PR DESCRIPTION
Because Maxscale for example splits read and write queries to differemt cluster member, there are several connection from MaxScale to the DB server.
Each connections has its own timeout (wait_timeout) to be disconnected.
Example:
- wait_timeout 50 seconds
- 1 write query 
- 70 seconds read queries (write connection behind MaxScale never used, closed after 50s)
- 1 write query fail: "Conenction lost"