### PR TITLE
Added connection.state === 'disconnected' to Connection.prototype.end

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -245,6 +245,7 @@ Connection.prototype.end = function end(options, callback) {
     opts.timeout = 30000;
   }
 
+  this.state = 'disconnected';
   this._implyConnect();
   this._protocol.quit(opts, bindToCurrentDomain(cb));
 };

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -245,7 +245,6 @@ Connection.prototype.end = function end(options, callback) {
     opts.timeout = 30000;
   }
 
-  this.state = 'disconnected';
   this._implyConnect();
   this._protocol.quit(opts, bindToCurrentDomain(cb));
 };

--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -158,6 +158,7 @@ Protocol.prototype._enqueue = function(sequence) {
       self._emitPacket(packet);
     })
     .on('end', function() {
+      self._connection.state = 'disconnected';
       self._dequeue(sequence);
     })
     .on('timeout', function() {

--- a/test/integration/connection/test-connection-end.js
+++ b/test/integration/connection/test-connection-end.js
@@ -1,0 +1,20 @@
+var assert = require('assert');
+var common = require('../../common');
+
+// Should end a connection without the optional callback; does not gurantee
+// that the connection.state === 'disconnected'
+common.getTestConnection(function (err, connection) {
+  assert.ifError(err);
+  connection.end();
+});
+
+// Should end a connection with the optional callback and ensure that
+// connection.state === 'disconnected'
+common.getTestConnection(function (err, connection) {
+  assert.ifError(err);
+
+  connection.end(function (err) {
+    assert.ifError(err);
+    assert.ok(connection.state === 'disconnected');
+  });
+});


### PR DESCRIPTION
This was a pretty easy fix and should resolve the issue https://github.com/mysqljs/mysql/issues/1887 that I opened earlier. I did not make the changes to Pool.js, though. The same issues were cropping up with the `.release()` method.