### PR TITLE
Added support for COM_INIT_DB in FakeServer.js

### DIFF
--- a/lib/protocol/packets/ComInitDbPacket.js
+++ b/lib/protocol/packets/ComInitDbPacket.js
@@ -1,0 +1,15 @@
+module.exports = ComInitDbPacket;
+function ComInitDbPacket(database_name) {
+  this.command = 0x02;
+  this.database_name     = database_name;
+}
+
+ComInitDbPacket.prototype.write = function(writer) {
+  writer.writeUnsignedNumber(1, this.command);
+  writer.writeString(this.database_name);
+};
+
+ComInitDbPacket.prototype.parse = function(parser) {
+  this.command = parser.parseUnsignedNumber(1);
+  this.database_name     = parser.parsePacketTerminatedString();
+};

--- a/lib/protocol/packets/index.js
+++ b/lib/protocol/packets/index.js
@@ -20,3 +20,4 @@ exports.RowDataPacket = require('./RowDataPacket');
 exports.SSLRequestPacket = require('./SSLRequestPacket');
 exports.StatisticsPacket = require('./StatisticsPacket');
 exports.UseOldPasswordPacket = require('./UseOldPasswordPacket');
+exports.ComInitDbPacket = require('./ComInitDbPacket');

--- a/test/FakeServer.js
+++ b/test/FakeServer.js
@@ -302,6 +302,12 @@ FakeConnection.prototype._parsePacket = function(header) {
         this._handleQueryPacket(packet);
       }
       break;
+    case Packets.ComInitDbPacket:
+      if (!this.emit('init_db', packet)) {
+        this._sendPacket(new Packets.OkPacket());
+        this._parser.resetPacketNumber();
+      }
+      break;
     case Packets.ComPingPacket:
       if (!this.emit('ping', packet)) {
         this._sendPacket(new Packets.OkPacket());
@@ -370,6 +376,7 @@ FakeConnection.prototype._determinePacket = function(header) {
   var firstByte = this._parser.peak();
   switch (firstByte) {
     case 0x01: return Packets.ComQuitPacket;
+    case 0x02: return Packets.ComInitDbPacket;
     case 0x03: return Packets.ComQueryPacket;
     case 0x0e: return Packets.ComPingPacket;
     case 0x11: return Packets.ComChangeUserPacket;


### PR DESCRIPTION
Hi,
I use FakeServer.js to do automatic regression test generation for some applications that I was assigned to but that the previous devs didn't bother to write functional tests to.
One of such applications issued a COM_INIT_DB command that FakeServer.js doesn't support which was added in this commit.
