### PR TITLE
Updates for nodejs 10 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ node_js:
   - "7.10"
   - "8.10"
   - "9.8"
+  - "10.2"
 env:
   global:
     # Necessary to build Node.js 0.6 on Travis CI images

--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -1,7 +1,7 @@
 var Parser       = require('./Parser');
 var Sequences    = require('./sequences');
 var Packets      = require('./packets');
-var Timers       = require('timers');
+var Timers       = require('./Timers');
 var Stream       = require('stream').Stream;
 var Util         = require('util');
 var PacketWriter = require('./PacketWriter');
@@ -154,7 +154,9 @@ Protocol.prototype._enqueue = function(sequence) {
       self._delegateError(err, sequence);
     })
     .on('packet', function(packet) {
-      Timers.active(sequence);
+      if (sequence._timer) {
+        sequence._timer.refresh();
+      }
       self._emitPacket(packet);
     })
     .on('end', function() {
@@ -170,7 +172,9 @@ Protocol.prototype._enqueue = function(sequence) {
       self._delegateError(err, sequence);
     })
     .on('start-tls', function() {
-      Timers.active(sequence);
+      if (sequence._timer) {
+        sequence._timer.refresh();
+      }
       self._connection._startTLS(function(err) {
         if (err) {
           // SSL negotiation error are fatal
@@ -180,7 +184,9 @@ Protocol.prototype._enqueue = function(sequence) {
           return;
         }
 
-        Timers.active(sequence);
+        if (sequence._timer) {
+          sequence._timer.refresh();
+        }
         sequence._tlsUpgradeCompleteHandler();
       });
     });
@@ -265,7 +271,9 @@ Protocol.prototype._parsePacket = function() {
     this._handshakeInitializationPacket = packet;
   }
 
-  Timers.active(sequence);
+  if (sequence._timer) {
+    sequence._timer.refresh();
+  }
 
   if (!sequence[packetName]) {
     var err   = new Error('Received packet in the wrong sequence.');
@@ -322,7 +330,7 @@ Protocol.prototype._determinePacket = function(sequence) {
 };
 
 Protocol.prototype._dequeue = function(sequence) {
-  Timers.unenroll(sequence);
+  sequence._timer = Timers.clearTimeout(sequence._timer);
 
   // No point in advancing the queue, we are dead
   if (this._fatalError) {
@@ -344,8 +352,9 @@ Protocol.prototype._dequeue = function(sequence) {
 
 Protocol.prototype._startSequence = function(sequence) {
   if (sequence._timeout > 0 && isFinite(sequence._timeout)) {
-    Timers.enroll(sequence, sequence._timeout);
-    Timers.active(sequence);
+    sequence._timer = Timers.setTimeout(function() {
+      sequence._onTimeout();
+    }, sequence._timeout);
   }
 
   if (sequence.constructor === Sequences.ChangeUser) {

--- a/lib/protocol/Timers.js
+++ b/lib/protocol/Timers.js
@@ -1,0 +1,45 @@
+var Timers = require('timers');
+
+function hasRefresh() {
+  var testTimer = setTimeout(function() {}, 100);
+  var result = typeof testTimer.refresh === 'function';
+
+  clearTimeout(testTimer);
+
+  return result;
+}
+
+if (hasRefresh()) {
+  module.exports.setTimeout = setTimeout;
+  module.exports.clearTimeout = clearTimeout;
+} else {
+  module.exports.setTimeout = function setTimeout(callback, after) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('callback must be a function.');
+    }
+
+    var args = Array.prototype.slice.call(arguments, 2);
+    var timer = {
+      _idleNext    : null,
+      _idlePrev    : null,
+      _idleStart   : null,
+      _idleTimeout : -1,
+      _repeat      : null,
+      _onTimeout   : function _onTimeout() {
+        callback.apply(this, args);
+      },
+      refresh: function refresh() {
+        Timers.active(this);
+      }
+    };
+
+    Timers.enroll(timer, after);
+    Timers.active(timer);
+    return timer;
+  };
+  module.exports.clearTimeout = function clearTimeout(timer) {
+    if (timer) {
+      Timers.unenroll(timer);
+    }
+  };
+}

--- a/lib/protocol/sequences/Sequence.js
+++ b/lib/protocol/sequences/Sequence.js
@@ -25,13 +25,6 @@ function Sequence(options, callback) {
   this._callSite = null;
   this._ended    = false;
   this._timeout  = options.timeout;
-
-  // For Timers
-  this._idleNext    = null;
-  this._idlePrev    = null;
-  this._idleStart   = null;
-  this._idleTimeout = -1;
-  this._repeat      = null;
 }
 
 Sequence.determinePacket = function(byte) {

--- a/test/unit/connection/test-connection-ssl-ciphers.js
+++ b/test/unit/connection/test-connection-ssl-ciphers.js
@@ -1,10 +1,17 @@
 var assert     = require('assert');
 var common     = require('../../common');
+var tls        = require('tls');
+var tlsCipher = 'RC4-SHA';
+
+if (typeof tls.getCiphers === 'function') {
+  tlsCipher = tls.getCiphers()[0].toUpperCase();
+}
+
 var connection = common.createConnection({
   port : common.fakeServerPort,
   ssl  : {
     ca      : common.getSSLConfig().ca,
-    ciphers : 'RC4-SHA'
+    ciphers : tlsCipher
   }
 });
 
@@ -17,7 +24,7 @@ server.listen(common.fakeServerPort, function (err) {
     assert.ifError(err);
     assert.equal(rows.length, 1);
     assert.equal(rows[0].Variable_name, 'Ssl_cipher');
-    assert.equal(rows[0].Value, 'RC4-SHA');
+    assert.equal(rows[0].Value, tlsCipher);
 
     connection.destroy();
     server.destroy();


### PR DESCRIPTION
* Use setTimeout and .refresh if available.
* Enable testing of nodejs 10.2.1.
* Use 'tls.getCiphers()' if available to detect an available cipher for
  testing.

Fixes #2003.