### PR TITLE
Use LIFO for returning/retrieving connections from pool

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -367,8 +367,10 @@ time one is needed.
 
 Connections are lazily created by the pool. If you configure the pool to allow
 up to 100 connections, but only ever use 5 simultaneously, only 5 connections
-will be made. Connections are also cycled round-robin style, with connections
-being taken from the top of the pool and returning to the bottom.
+will be made. Connections are cycled on a last in first out basis, with connections
+being taken from the top and returning to the top of the pool. This allows for
+connections to be killed off by the server due to inactivity after `wait_timeout`
+for the connection has been reached.
 
 When a previous connection is retrieved from the pool, a ping packet is sent
 to the server to check if the connection is still good.

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -137,8 +137,8 @@ Pool.prototype.releaseConnection = function releaseConnection(connection) {
       // this won't catch all double-release cases
       throw new Error('Connection already released');
     } else {
-      // add connection to end of free queue
-      this._freeConnections.push(connection);
+      // add connection to front of free queue
+      this._freeConnections.unshift(connection);
       this.emit('release', connection);
     }
   }

--- a/test/unit/pool/test-connection-cycling.js
+++ b/test/unit/pool/test-connection-cycling.js
@@ -1,0 +1,45 @@
+var after  = require('after');
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+var lastConnectionId = null;
+var numberOfConnections = 4;
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var getConnectionAndEnsureItsTheLastConnection = function(cb) {
+    pool.getConnection(function (err, connection) {
+      assert.ifError(err);
+      assert.ok(connection.id === lastConnectionId);
+      connection.release();
+      if (cb) cb();
+    });
+  };
+
+  var done = after(numberOfConnections, function () {
+    getConnectionAndEnsureItsTheLastConnection(function() {
+      getConnectionAndEnsureItsTheLastConnection(function() {
+        pool.end(function (err) {
+          assert.ifError(err);
+          server.destroy();
+        });
+      });
+    });
+  });
+
+  var counter = 1;
+
+  var createIndexedConnection = function () {
+    pool.getConnection(function (err, connection) {
+      connection.id = counter++;
+      lastConnectionId = connection.id;
+      assert.ifError(err);
+      connection.release();
+      done();
+    });
+  };
+  Array.apply(null, {length: numberOfConnections}).map(createIndexedConnection);
+});


### PR DESCRIPTION
The current way this works (cycling through all of the connections) means that you can't make use of mysql's `wait_timeout` setting for closing inactive connections. Once a connection is created it will be persisted forever unless you have very low levels of activity.

Was there a reason to cycle round-robin through the connections when this was initially implemented?