### PR TITLE
Add new optional parameter to have all sockets send KeepAlive packets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -235,6 +235,7 @@ issue [#501](https://github.com/mysqljs/mysql/issues/501). (Default: `false`)
   also possible to blacklist default ones. For more information, check
   [Connection Flags](#connection-flags).
 * `ssl`: object with ssl parameters or a string containing name of ssl profile. See [SSL options](#ssl-options).
+* `keepAliveDelay`: Delay in milliseconds after which the connection socket will send a keepalive packet. See [Net.socket.setKeepAlive](https://nodejs.org/api/net.html#net_socket_setkeepalive_enable_initialdelay).
 
 
 In addition to passing these options as an object, you can also use a url

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -431,6 +431,9 @@ Connection.prototype._handleProtocolDrain = function() {
 
 Connection.prototype._handleProtocolConnect = function() {
   this.state = 'connected';
+  if (this.config.keepAliveDelay) {
+    this._socket.setKeepAlive(true, this.config.keepAliveDelay);
+  }
   this.emit('connect');
 };
 

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -37,6 +37,7 @@ function ConnectionConfig(options) {
   this.typeCast           = (options.typeCast === undefined)
     ? true
     : options.typeCast;
+  this.keepAliveDelay     = options.keepAliveDelay || 0;
 
   if (this.timezone[0] === ' ') {
     // "+" is a url encoded char for space so it

--- a/test/unit/connection/test-connect-keepalive.js
+++ b/test/unit/connection/test-connect-keepalive.js
@@ -1,6 +1,6 @@
 var assert     = require('assert');
 var common     = require('../../common');
-var connection = common.createConnection({keepAliveDelay : 60000, port: common.fakeServerPort});
+var connection = common.createConnection({keepAliveDelay: 60000, port: common.fakeServerPort});
 
 var server = common.createFakeServer();
 

--- a/test/unit/connection/test-connect-keepalive.js
+++ b/test/unit/connection/test-connect-keepalive.js
@@ -1,0 +1,16 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({keepAliveDelay : 60000, port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  connection.on('connect', function () {
+    connection.destroy();
+    server.destroy();
+  });
+
+  connection.connect(assert.ifError);
+});

--- a/test/unit/test-ConnectionConfig.js
+++ b/test/unit/test-ConnectionConfig.js
@@ -64,6 +64,17 @@ test('ConnectionConfig#Constructor', {
   'blacklists unsupported client flags': function() {
     var config = new ConnectionConfig({ flags: '+CONNECT_ATTRS' });
     assert.equal(config.clientFlags & common.ClientConstants.CLIENT_CONNECT_ATTRS, 0);
+  },
+
+  'Socket keepAlive defaults to 0 (default)': function() {
+    var config = new ConnectionConfig({});
+    assert.equal(config.keepAliveDelay, 0);
+  },
+
+  'Socket keepAlive is set in config': function()
+  {
+    var config = new ConnectionConfig({ keepAliveDelay : 60000 });
+    assert.equal(config.keepAliveDelay, 60000);
   }
 });
 

--- a/test/unit/test-ConnectionConfig.js
+++ b/test/unit/test-ConnectionConfig.js
@@ -73,7 +73,7 @@ test('ConnectionConfig#Constructor', {
 
   'Socket keepAlive is set in config': function()
   {
-    var config = new ConnectionConfig({ keepAliveDelay : 60000 });
+    var config = new ConnectionConfig({ keepAliveDelay: 60000 });
     assert.equal(config.keepAliveDelay, 60000);
   }
 });


### PR DESCRIPTION
So I work with the author of https://github.com/mysqljs/mysql/issues/1939

Today I decided that replacing our custom pool management with this project's implementation would solve a few bugs we had.  
And it did, great job, folks!  
  
However, the trigger happy load balancers are here to stay.  

Extending the fix given in the above issue was easy enough with Pools. (Hooking to the Pool's `connect` event worked like a charm). PoolClusters were another thing altogether...  

And (as we're working in TypeScript), the code was actually messier with the need to expose internal variables and attach event listeners to every internal pool.  

Hence this PR to add another configuration option to specify a keepAliveDelay, that, if set, is applied when a socket is created. Otherwise, it will use the system's settings. (Node's default is to not use a KeepAlive.)  

Side note : I'd be more than happy to update @types/mysql to reflect these changes once they are merged.