### PR TITLE
Query Observables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,12 @@ This file is a manually maintained list of changes for each release. Feel free
 to add your changes here when sending pull requests. Also send corrections if
 you spot any mistakes.
 
+## v2.16.1 (2018-10-20)
+
+* Add `rxjs ^6.3.3` to dependencies
+* Add `connection.queryObservable()`
+* Add `pool.queryObservable()`
+
 ## v2.16.0 (2018-07-17)
 
 * Add Amazon RDS GovCloud SSL certificates #1876

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ you spot any mistakes.
 
 ## v2.16.1 (2018-10-20)
 
-* Add `rxjs ^6.3.3` to dependencies
+* Add `rxjs@6.3.3` to dependencies
 * Add `connection.queryObservable()`
 * Add `pool.queryObservable()`
 

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@
 - [Executing queries in parallel](#executing-queries-in-parallel)
 - [Streaming query rows](#streaming-query-rows)
 - [Piping results with Streams](#piping-results-with-streams)
+- [Query data using Observables](#query-data-using-observables)
 - [Multiple statement queries](#multiple-statement-queries)
 - [Stored procedures](#stored-procedures)
 - [Joins with overlapping column names](#joins-with-overlapping-column-names)
@@ -974,6 +975,38 @@ connection.query('SELECT * FROM posts')
   .stream({highWaterMark: 5})
   .pipe(...);
 ```
+
+## Query data using Observables
+
+If you're familiar with ReactiveX Observables and Operators, you can use Subscription-on-Observable instead of callbacks to get your data. Read more about Observables [here](https://rxjs-dev.firebaseapp.com/guide/observable).
+Use `Connection.queryObservable()` or `Pool.queryObservable()`(if you're using a pool) to query data instead of `.query()`.
+`.queryObservable()` returns an Observable which you'll subscribe to.
+Examples:
+
+```js
+var query = connection.queryObservable('SELECT * FROM posts');
+
+var results = []
+query.subscribe(function(row) {
+  // results streaming section
+  results.push(row); // pushes row-by-row to `results` array
+
+}, function(err) {
+  // error handling section
+  console.error(err); 
+
+}, function() {
+  // completion section
+  console.log(results);  // logs all retrieved rows
+
+})
+```
+
+Take these in consideration when using this method:
+* If you want to run the same query multiple times, you don't need to re-create the Observable again, just re-subscribe on the same Observable
+* Subscription section recieves data row-by-row, so avoid using multiple statements in one query because rows will be mixed.
+* Currently, this method doesn't support retrieving `fields` object with results.
+
 
 ## Multiple statement queries
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -7,6 +7,7 @@ var Protocol         = require('./protocol/Protocol');
 var SqlString        = require('./protocol/SqlString');
 var Query            = require('./protocol/sequences/Query');
 var Util             = require('util');
+var rxjs             = require('rxjs');
 
 module.exports = Connection;
 Util.inherits(Connection, Events.EventEmitter);
@@ -503,3 +504,16 @@ function wrapToDomain(ee, fn) {
     }
   };
 }
+
+Connection.prototype.queryObservable = function queryObservable(sql, values) {
+  var connection = this;
+  return new rxjs.Observable(function(observer){
+    connection.query(sql, values).on('error', function(err) {
+      observer.error(err);
+    }).on('result', function(row) {
+      observer.next(row);
+    }).on('end', function() {
+      observer.complete();
+    });
+  });
+};

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -3,6 +3,8 @@ var Connection     = require('./Connection');
 var EventEmitter   = require('events').EventEmitter;
 var Util           = require('util');
 var PoolConnection = require('./PoolConnection');
+var rxjs           = require('rxjs');
+var rxjsOperators  = require('rxjs/operators');
 
 module.exports = Pool;
 
@@ -283,6 +285,33 @@ Pool.prototype.escape = function(value) {
 
 Pool.prototype.escapeId = function escapeId(value) {
   return mysql.escapeId(value, false);
+};
+
+Pool.prototype.queryObservable = function queryObservable(sql, values) {
+  var pool = this;
+
+  return rxjs.bindNodeCallback(pool.getConnection).call(pool).pipe(
+    rxjsOperators.flatMap(function(conn) {
+      var query = Connection.createQuery(sql, values, undefined);
+
+      if (!(typeof sql === 'object' && 'typeCast' in sql)) {
+        query.typeCast = pool.config.connectionConfig.typeCast;
+      }
+
+      if (pool.config.connectionConfig.trace) {
+        // Long stack trace support
+        query._callSite = new Error();
+      }
+
+      // Release connection based off event
+      query.once('end', function() {
+        conn.release();
+      });
+
+      return conn.queryObservable(query);
+    })
+  );
+
 };
 
 function spliceConnection(array, connection) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bignumber.js": "4.1.0",
     "readable-stream": "2.3.6",
-    "rxjs": "^6.3.3",
+    "rxjs": "6.3.3",
     "safe-buffer": "5.1.2",
     "sqlstring": "2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bignumber.js": "4.1.0",
     "readable-stream": "2.3.6",
-    "rxjs": "6.3.3",
+    "rxjs": "5.6.0-forward-compat.5",
     "safe-buffer": "5.1.2",
     "sqlstring": "2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mysql",
   "description": "A node.js driver for mysql. It is written in JavaScript, does not require compiling, and is 100% MIT licensed.",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "license": "MIT",
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "contributors": [
@@ -15,6 +15,7 @@
   "dependencies": {
     "bignumber.js": "4.1.0",
     "readable-stream": "2.3.6",
+    "rxjs": "^6.3.3",
     "safe-buffer": "5.1.2",
     "sqlstring": "2.3.1"
   },

--- a/test/unit/connection/test-query-observable-after-destroy.js
+++ b/test/unit/connection/test-query-observable-after-destroy.js
@@ -1,0 +1,23 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var sync = true;
+
+  connection.destroy();
+
+  connection.queryObservable('SELECT 1').subscribe(function() { }, function(err) {
+    assert.ok(!sync);
+    assert.ok(err);
+    assert.equal(err.fatal, false);
+    assert.equal(err.code, 'PROTOCOL_ENQUEUE_AFTER_DESTROY');
+    server.destroy();
+  });
+
+  sync = false;
+});

--- a/test/unit/connection/test-query-observable-after-end.js
+++ b/test/unit/connection/test-query-observable-after-end.js
@@ -1,0 +1,28 @@
+var after      = require('after');
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var done = after(2, function () {
+    server.destroy();
+  });
+
+  connection.connect(assert.ifError);
+
+  connection.end(function (err) {
+    assert.ifError(err);
+    done();
+  });
+
+  connection.queryObservable('SELECT 1').subscribe(function () { }, function(err) {
+    assert.ok(err);
+    assert.equal(err.fatal, false);
+    assert.equal(err.code, 'PROTOCOL_ENQUEUE_AFTER_QUIT');
+    done();
+  });
+});

--- a/test/unit/connection/test-query-observable-timeout.js
+++ b/test/unit/connection/test-query-observable-timeout.js
@@ -1,0 +1,31 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+var server     = common.createFakeServer();
+
+var timer = setTimeout(function () {
+  throw new Error('test timeout');
+}, 2000);
+
+server.listen(common.fakeServerPort, function(err) {
+  if (err) throw err;
+
+  connection.queryObservable({sql: 'SELECT 1', timeout: 200}).subscribe(function () { }, function(err) {
+    assert.ok(err);
+    assert.equal(err.code, 'PROTOCOL_SEQUENCE_TIMEOUT');
+    assert.equal(err.fatal, true);
+    assert.equal(err.message, 'Query inactivity timeout');
+    assert.equal(err.timeout, 200);
+  });
+});
+
+server.on('connection', function(conn) {
+  conn.handshake();
+  conn._socket.on('close', function() {
+    clearTimeout(timer);
+    server.destroy();
+  });
+  conn.on('query', function () {
+    // Do nothing; timeout
+  });
+});

--- a/test/unit/pool/test-query-observable-stream-connection-error.js
+++ b/test/unit/pool/test-query-observable-stream-connection-error.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({port: common.fakeServerPort});
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var query = pool.queryObservable('SELECT 1');
+
+  query.subscribe(function(){}, function(err){
+    assert.ok(err, 'got error');
+    assert.equal(err.code, 'ER_ACCESS_DENIED_ERROR');
+    assert.equal(err.fatal, true);
+    server.destroy();
+  });
+
+});
+
+server.on('connection', function (conn) {
+  conn.deny();
+});

--- a/test/unit/pool/test-query-observable-streaming-rows.js
+++ b/test/unit/pool/test-query-observable-streaming-rows.js
@@ -1,0 +1,44 @@
+var after  = require('after');
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var done = after(1, function () {
+    pool.end(function (err) {
+      assert.ifError(err);
+      server.destroy();
+    });
+  });
+
+  pool.getConnection(function (err, connection) {
+    assert.ifError(err);
+
+    var count  = 0;
+    var paused = false;
+    var query  = connection.queryObservable('SELECT * FROM stream LIMIT 5');
+
+    query.subscribe(function (row) {
+      count++;
+
+      assert.equal(paused, false);
+      assert.equal(row.id, count);
+
+      paused = true;
+      connection.pause();
+
+      setTimeout(function () {
+        paused = false;
+        connection.resume();
+      }, 50);
+    }, function(){}, function () {
+      connection.release();
+      done();
+    });
+
+  });
+});

--- a/test/unit/pool/test-query-observable.js
+++ b/test/unit/pool/test-query-observable.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({port: common.fakeServerPort});
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var rows = [];
+  pool.queryObservable('SELECT 1').subscribe(function (row) {
+    rows.push(row);
+  }, assert.ifError, function() {
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]['1'], 1);
+
+    // Should work without error
+    pool.queryObservable('SELECT SQL_ERROR');
+
+    pool.end(function(err) {
+      assert.ifError(err);
+      server.destroy();
+    });
+  });
+});

--- a/test/unit/query-observable/test-error-event-fatal.js
+++ b/test/unit/query-observable/test-error-event-fatal.js
@@ -1,0 +1,11 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.bogusPort});
+
+var query = connection.queryObservable('SELECT 1');
+
+query.subscribe(function(){ }, function (err) {
+  assert.ok(err, 'got error');
+  assert.equal(err.code, 'ECONNREFUSED');
+  assert.equal(err.fatal, true);
+});

--- a/test/unit/query-observable/test-error-event.js
+++ b/test/unit/query-observable/test-error-event.js
@@ -1,0 +1,20 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var query = connection.queryObservable('INVALID SQL');
+
+  query.subscribe(function(){ }, function (err) {
+    assert.ok(err, 'got error');
+    assert.equal(err.code, 'ER_PARSE_ERROR');
+    assert.equal(err.sql, 'INVALID SQL');
+    assert.ok(!err.fatal);
+    connection.destroy();
+    server.destroy();
+  });
+});

--- a/test/unit/query-observable/test-query-end-after-error.js
+++ b/test/unit/query-observable/test-query-end-after-error.js
@@ -1,0 +1,22 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+process.on('uncaughtException', function (err) {
+  if (err.code !== 'ER_PARSE_ERROR') throw err;
+});
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var query = connection.queryObservable('SELECT INVALID');
+
+  query.subscribe(function(){ }, function () {
+    connection.end(function (err) {
+      assert.ifError(err);
+      server.destroy();
+    });
+  });
+});

--- a/test/unit/query-observable/test-query-events.js
+++ b/test/unit/query-observable/test-query-events.js
@@ -1,0 +1,24 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  var rows   = [];
+
+  var query = connection.queryObservable('SELECT 1');
+
+  query.subscribe(function(row){
+    rows.push(row);
+  }, assert.ifError, function(){ });
+
+  connection.end(function (err) {
+    assert.ifError(err);
+    assert.deepEqual(rows, [{1: 1}]);
+    server.destroy();
+  });
+
+});

--- a/test/unit/query-observable/test-result-rows-enumerate.js
+++ b/test/unit/query-observable/test-result-rows-enumerate.js
@@ -1,0 +1,28 @@
+var assert     = require('assert');
+var common     = require('../../common');
+var connection = common.createConnection({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  connection.queryObservable('SELECT CURRENT_USER()').subscribe(function(row) {
+    var keys = Object.keys(row).sort();
+
+    assert.equal(keys.length, 1);
+    assert.deepEqual(keys, ['CURRENT_USER()']);
+
+    var forin = [];
+    for (var column in row) {
+      forin.push(column);
+    }
+
+    assert.deepEqual(forin, keys);
+
+    connection.destroy();
+    server.destroy();
+  }, function(err) {
+    assert.ifError(err);
+  });
+});


### PR DESCRIPTION
This pull request adds new feature 'Query Observables'.
It uses ReactiveX Observables as an interface for retrieving data instead of callbacks way.

Observables has replaced Promises and getting more used, I think a feature like this will be satisfying for many developers.

The pull request has test cases for the new added methods and they run as expected.
