### PR TITLE
Add hints for yarn install

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,10 +69,10 @@ Installation is done using the
 $ npm install mysql
 ```
 
-You can also install mysqljs using the [Yarn package manager](https://yarnpkg.com/lang/en/docs/install/). Yarn is an alternative to npm, which enables a flat dependency tree.
+You can also install this module using the [Yarn package manager](https://yarnpkg.com/lang/en/docs/install/). Yarn is an alternative to npm, which enables a flat dependency tree.
 
 ```sh
-$ yarn add mysql --flat
+$ yarn add mysql
 ```
 
 For information about the previous 0.9.x releases, visit the [v0.9 branch][].
@@ -84,10 +84,10 @@ if a bugfix is working. In this case, please do:
 $ npm install mysqljs/mysql
 ```
 
-For Yarn, it look as follows:
+For Yarn, it would be the following command:
 
 ```sh
-$ yarn add mysqljs/mysql --flat
+$ yarn add mysqljs/mysql
 ```
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,12 @@ Installation is done using the
 $ npm install mysql
 ```
 
+You can also install mysqljs using the [Yarn package manager](https://yarnpkg.com/lang/en/docs/install/). Yarn is an alternative to npm, which enables a flat dependency tree.
+
+```sh
+$ yarn add mysql --flat
+```
+
 For information about the previous 0.9.x releases, visit the [v0.9 branch][].
 
 Sometimes I may also ask you to install the latest version from Github to check
@@ -77,6 +83,13 @@ if a bugfix is working. In this case, please do:
 ```sh
 $ npm install mysqljs/mysql
 ```
+
+For Yarn, it look as follows:
+
+```sh
+$ yarn add mysqljs/mysql --flat
+```
+
 
 [v0.9 branch]: https://github.com/mysqljs/mysql/tree/v0.9
 


### PR DESCRIPTION
The docs and readme are very thorough. Very nice! I spent a little extra time verifying that the yarn package with name `mysql` was the same and that the `mysqljs/mysql` install worked and that `--flat` would work as expected.  

commit message: Install with yarn. Confirm that the commands point to the correct package. And acknowledge additional audience/user support.