### PR TITLE
Add connectionLifetime to pool options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ you spot any mistakes.
 * Remove special case for handshake in determine packet code
 * Small performance improvement starting command sequence
 * Support Node.js 11.x
+* Add `connectionLifetime` to pool options
 
 ## v2.16.0 (2018-07-17)
 

--- a/Readme.md
+++ b/Readme.md
@@ -391,6 +391,9 @@ constructor. In addition to those options pools accept a few extras:
 * `queueLimit`: The maximum number of connection requests the pool will queue
   before returning an error from `getConnection`. If set to `0`, there is no
   limit to the number of queued connection requests. (Default: `0`)
+* `connectionLifetime`: The maximum number of milliseconds a connection can be
+  alive in the pool. If set to `0` connection will live until it is manually
+  destroyed or the pool is closed. (Default: `0`)
 
 ## Pool events
 

--- a/lib/PoolConfig.js
+++ b/lib/PoolConfig.js
@@ -20,6 +20,9 @@ function PoolConfig(options) {
   this.queueLimit         = (options.queueLimit === undefined)
     ? 0
     : Number(options.queueLimit);
+  this.connectionLifetime         = (options.connectionLifetime === undefined)
+    ? 0
+    : Number(options.connectionLifetime);
 }
 
 PoolConfig.prototype.newConnectionConfig = function newConnectionConfig() {

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -9,6 +9,13 @@ function PoolConnection(pool, options) {
   Connection.call(this, options);
   this._pool  = pool;
 
+  if (this._pool.config.connectionLifetime) {
+    this._lifetimeout = setTimeout(
+      this.destroy.bind(this),
+      this._pool.config.connectionLifetime
+    );
+  }
+
   // Bind connection to pool domain
   if (Events.usingDomains) {
     this.domain = pool.domain;
@@ -54,6 +61,10 @@ PoolConnection.prototype.destroy = function () {
 };
 
 PoolConnection.prototype._removeFromPool = function _removeFromPool() {
+  if (this._lifetimeout) {
+    clearTimeout(this._lifetimeout);
+  }
+
   if (!this._pool || this._pool._closed) {
     return;
   }

--- a/test/unit/pool/test-connection-lifetime.js
+++ b/test/unit/pool/test-connection-lifetime.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({
+  port               : common.fakeServerPort,
+  connectionLifetime : 100
+});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function(err){
+  assert.ifError(err);
+
+  pool.getConnection(function (err, connection) {
+    assert.ifError(err);
+    assert.ok(connection);
+
+    setTimeout(function() {
+      assert.equal(connection.state, 'disconnected');
+      pool.end(function (err) {
+        assert.ifError(err);
+        server.destroy();
+      });
+    }, 200);
+
+  });
+});


### PR DESCRIPTION
This option is specially useful when connecting to serverless databases, in which the instances are turned off when there is no connection alive.

Fixes #1276 