### PR TITLE
Test on node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ node_js:
   - "9.11"
   - "10.15"
   - "11.14"
+  - "12.0"
 env:
   global:
     # Necessary to build Node.js 0.6 on Travis CI images

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,10 @@ This file is a manually maintained list of changes for each release. Feel free
 to add your changes here when sending pull requests. Also send corrections if
 you spot any mistakes.
 
+## HEAD
+
+* Support Node.js 12.x #2211
+
 ## v2.17.1 (2019-04-18)
 
 * Update `bignumber.js` to 7.2.1 #2206

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
     - nodejs_version: "9.11"
     - nodejs_version: "10.15"
     - nodejs_version: "11.14"
+    - nodejs_version: "12.0"
 
 services:
   - mysql


### PR DESCRIPTION
Since node v12 is the current stable version of node, we should be testing it in our CI environment.

I also added `package-lock.json` to `.gitignore` since it looks like you don't want it committed to the repo. I'd be happy to remove this if you prefer to keep things as they are.

