### PR TITLE
Add idleConnectionTimeout to pool options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ you spot any mistakes.
 ## HEAD
 
 * Support Node.js 12.x #2211
+* Add `idleConnectionTimeout` to pool options
 
 ## v2.17.1 (2019-04-18)
 

--- a/Readme.md
+++ b/Readme.md
@@ -393,6 +393,9 @@ constructor. In addition to those options pools accept a few extras:
 * `queueLimit`: The maximum number of connection requests the pool will queue
   before returning an error from `getConnection`. If set to `0`, there is no
   limit to the number of queued connection requests. (Default: `0`)
+* `idleConnectionTimeout`: The maximum number of milliseconds a connection can be
+  idle in the pool. If set to `0` connection will live until it is manually
+  destroyed or the pool is closed. (Default: `0`)
 
 ## Pool events
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -106,6 +106,11 @@ Pool.prototype.acquireConnection = function acquireConnection(connection, cb) {
       pool.emit('connection', connection);
     }
 
+    if (connection._idleTimeout) {
+      clearTimeout(connection._idleTimeout);
+      connection._idleTimeout = null;
+    }
+
     pool.emit('acquire', connection);
     cb(null, connection);
   }

--- a/lib/PoolConfig.js
+++ b/lib/PoolConfig.js
@@ -20,6 +20,9 @@ function PoolConfig(options) {
   this.queueLimit         = (options.queueLimit === undefined)
     ? 0
     : Number(options.queueLimit);
+  this.idleConnectionTimeout         = (options.idleConnectionTimeout === undefined)
+    ? 0
+    : Number(options.idleConnectionTimeout);
 }
 
 PoolConfig.prototype.newConnectionConfig = function newConnectionConfig() {

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -5,6 +5,8 @@ var Events     = require('events');
 module.exports = PoolConnection;
 inherits(PoolConnection, Connection);
 
+function _noop() {}
+
 function PoolConnection(pool, options) {
   Connection.call(this, options);
   this._pool  = pool;
@@ -34,7 +36,7 @@ PoolConnection.prototype.release = function release() {
 
   if (this._pool.config.idleConnectionTimeout) {
     this._idleTimeout = setTimeout(
-      this.destroy.bind(this),
+      this._realEnd.bind(this, _noop),
       this._pool.config.idleConnectionTimeout
     );
   }

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -32,6 +32,13 @@ PoolConnection.prototype.release = function release() {
     return undefined;
   }
 
+  if (this._pool.config.idleConnectionTimeout) {
+    this._idleTimeout = setTimeout(
+      this.destroy.bind(this),
+      this._pool.config.idleConnectionTimeout
+    );
+  }
+
   return pool.releaseConnection(this);
 };
 
@@ -56,6 +63,11 @@ PoolConnection.prototype.destroy = function () {
 PoolConnection.prototype._removeFromPool = function _removeFromPool() {
   if (!this._pool || this._pool._closed) {
     return;
+  }
+
+  if (this._idleTimeout) {
+    clearTimeout(this._idleTimeout);
+    this._idleTimeout = null;
   }
 
   var pool = this._pool;

--- a/test/unit/pool/test-idle-connection-timeout.js
+++ b/test/unit/pool/test-idle-connection-timeout.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({
+  port                  : common.fakeServerPort,
+  idleConnectionTimeout : 100
+});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function(err){
+  assert.ifError(err);
+
+  pool.once('release', function(connection) {
+    assert.ok(connection);
+    setTimeout(function() {
+      assert.equal(connection.state, 'disconnected');
+      pool.end(function (err) {
+        assert.ifError(err);
+        server.destroy();
+      });
+    }, 200);
+  });
+
+  pool.getConnection(function (err, firstConnection) {
+    assert.ifError(err);
+    assert.ok(firstConnection);
+    setTimeout(function() {
+      pool.getConnection(function (err, connection) {
+        assert.ifError(err);
+        assert.equal(connection.state, 'authenticated');
+        assert.equal(connection._idleTimeout, null);
+        assert.equal(firstConnection, connection);
+        connection.release();
+      });
+    }, 75);
+    firstConnection.release();
+  });
+});


### PR DESCRIPTION
This option is specially useful when connecting to serverless databases, in which the instances are turned off when there is no connection alive.

Coming from #2195.

This aims to close #1276 and resolve #962.
