### PR TITLE
Add support for 'mysql_clear_password'

### DIFF
--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -66,7 +66,7 @@ ConnectionConfig.mergeFlags = function mergeFlags(defaultFlags, userFlags) {
 
   // Merge the new flags
   for (var flag in newFlags) {
-    if (allFlags[flag] !== false) {
+    if (allFlags[flag] !== newFlags[flag]) {
       allFlags[flag] = newFlags[flag];
     }
   }

--- a/lib/protocol/Auth.js
+++ b/lib/protocol/Auth.js
@@ -8,6 +8,8 @@ function auth(name, data, options) {
   switch (name) {
     case 'mysql_native_password':
       return Auth.token(options.password, data.slice(0, 20));
+    case 'mysql_clear_password':
+      return Buffer.from(options.password);
     default:
       return undefined;
   }

--- a/test/integration/connection/test-clear-auth-bad.js
+++ b/test/integration/connection/test-clear-auth-bad.js
@@ -1,6 +1,0 @@
-var assert = require('assert');
-var common = require('../../common');
-
-common.getTestConnection({ flags: ['-PLUGIN_AUTH'] }, function (err) {
-  assert.ok(err, 'got error');
-});

--- a/test/integration/connection/test-clear-auth-bad.js
+++ b/test/integration/connection/test-clear-auth-bad.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+var common = require('../../common');
+
+common.getTestConnection({ flags: ['-PLUGIN_AUTH'] }, function (err) {
+  assert.ok(err, 'got error');
+});

--- a/test/integration/connection/test-clear-auth.js
+++ b/test/integration/connection/test-clear-auth.js
@@ -1,0 +1,7 @@
+var assert = require('assert');
+var common = require('../../common');
+
+common.getTestConnection({ flags: ['+PLUGIN_AUTH'] }, function (err, connection) {
+  assert.ifError(err, 'got error');
+  connection.destroy();
+});


### PR DESCRIPTION
This addition is two-fold. First of all, it allows user-set flags to enable flags that were disabled by default. This allows users to enable the PLUGIN_AUTH flag. Second and finally, it adds a case auth handler for the 'mysql_clear_password' auth plugin. This case simply returns the password, in plain text, as a buffer. These  both work in conjunction to allow for users to connect to databases that request the 'mysql_clear_password' plugin. ~~This solves #2001~~ This enables support for MariaDB servers using the [PAM Authentication Plugin](https://mariadb.com/kb/en/library/authentication-plugin-pam), the user just has to add `flags: ['+PLUGIN_AUTH']` to their options object. I could have changed the default for this flag, but I am unaware of the consequences of enabling it by default, so I left it up to the user to enable it. This is tested and works on my machine for a MariaDB database provided by my university for my database course.