### PR TITLE
App crashing fix due to protocol error

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -420,7 +420,9 @@ Connection.prototype._handleNetworkError = function(err) {
 
 Connection.prototype._handleProtocolError = function(err) {
   this.state = 'protocol_error';
-  this.emit('error', err);
+  try {
+    this.emit('error', err);
+  } catch(err) {}
 };
 
 Connection.prototype._handleProtocolDrain = function() {


### PR DESCRIPTION
protocol error emits error event which is not properly handleled which causes node app crash.
Its a preventation of app crash