### PR TITLE
request to turn on plugin_auth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -337,8 +337,7 @@ The following flags are available:
 - `ODBC` Special handling of ODBC behaviour. This flag has no effect on this Node.js
   implementation. (Default on)
 - `PLUGIN_AUTH` - Uses the plugin authentication mechanism when connecting to the
-  MySQL server. This feature is not currently supported by the Node.js implementation
-  so cannot be turned on. (Default off)
+  MySQL server.  Support auth plugin method "mysql_native_password" (Default on)
 - `PROTOCOL_41` - Uses the 4.1 protocol. (Default on)
 - `PS_MULTI_RESULTS` - Can handle multiple resultsets for execute. (Default on)
 - `REMEMBER_OPTIONS` - This is specific to the C client, and has no effect on this

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -109,7 +109,7 @@ ConnectionConfig.getDefaultFlags = function getDefaultFlags(options) {
     '+LONG_PASSWORD',     // Use the improved version of Old Password Authentication
     '+MULTI_RESULTS',     // Can handle multiple resultsets for COM_QUERY
     '+ODBC',              // Special handling of ODBC behaviour
-    '-PLUGIN_AUTH',       // Does *NOT* support auth plugins
+    '+PLUGIN_AUTH',       // Support auth plugin "mysql_native_password"
     '+PROTOCOL_41',       // Uses the 4.1 protocol
     '+PS_MULTI_RESULTS',  // Can handle multiple resultsets for COM_STMT_EXECUTE
     '+RESERVED',          // Unused

--- a/lib/protocol/packets/ClientAuthenticationPacket.js
+++ b/lib/protocol/packets/ClientAuthenticationPacket.js
@@ -1,4 +1,6 @@
 var Buffer = require('safe-buffer').Buffer;
+var ConnectionConfig = require('../../ConnectionConfig');
+var Client = require('../constants/client');
 
 module.exports = ClientAuthenticationPacket;
 function ClientAuthenticationPacket(options) {
@@ -12,6 +14,13 @@ function ClientAuthenticationPacket(options) {
   this.scrambleBuff  = options.scrambleBuff;
   this.database      = options.database;
   this.protocol41    = options.protocol41;
+
+  let defaultFlags = ConnectionConfig.getDefaultFlags();
+  let mergedFlags = ConnectionConfig.mergeFlags(defaultFlags, this.clientFlags);
+  if(mergedFlags & Client.CLIENT_PLUGIN_AUTH != 0) {
+      this.clientAuthPlugin = true;
+      this.authPluginName   = "mysql_native_pasword";
+  }
 }
 
 ClientAuthenticationPacket.prototype.parse = function(parser) {
@@ -23,6 +32,9 @@ ClientAuthenticationPacket.prototype.parse = function(parser) {
     this.user          = parser.parseNullTerminatedString();
     this.scrambleBuff  = parser.parseLengthCodedBuffer();
     this.database      = parser.parseNullTerminatedString();
+    if(this.clientAuthPlugin) {
+      this.authPluginName = parser.parseNullTerminatedString();
+    }
   } else {
     this.clientFlags   = parser.parseUnsignedNumber(2);
     this.maxPacketSize = parser.parseUnsignedNumber(3);
@@ -41,6 +53,9 @@ ClientAuthenticationPacket.prototype.write = function(writer) {
     writer.writeNullTerminatedString(this.user);
     writer.writeLengthCodedBuffer(this.scrambleBuff);
     writer.writeNullTerminatedString(this.database);
+    if(this.clientAuthPlugin) {
+      writer.writeNullTerminatedString(this.authPluginName);
+    }
   } else {
     writer.writeUnsignedNumber(2, this.clientFlags);
     writer.writeUnsignedNumber(3, this.maxPacketSize);

--- a/lib/protocol/packets/ComChangeUserPacket.js
+++ b/lib/protocol/packets/ComChangeUserPacket.js
@@ -1,4 +1,8 @@
 module.exports = ComChangeUserPacket;
+
+var ConnectionConfig = require('../../ConnectionConfig');
+var Client = require('../constants/client');
+
 function ComChangeUserPacket(options) {
   options = options || {};
 
@@ -15,6 +19,11 @@ ComChangeUserPacket.prototype.parse = function(parser) {
   this.scrambleBuff  = parser.parseLengthCodedBuffer();
   this.database      = parser.parseNullTerminatedString();
   this.charsetNumber = parser.parseUnsignedNumber(1);
+  let defaultFlags   = ConnectionConfig.getDefaultFlags();
+  let mergedFlags    = ConnectionConfig.mergeFlags(defaultFlags);
+  if(mergedFlags & Client.CLIENT_PLUGIN_AUTH != 0) {
+    this.authPluginName = parser.parseNullTerminatedString();
+  }
 };
 
 ComChangeUserPacket.prototype.write = function(writer) {
@@ -23,4 +32,9 @@ ComChangeUserPacket.prototype.write = function(writer) {
   writer.writeLengthCodedBuffer(this.scrambleBuff);
   writer.writeNullTerminatedString(this.database);
   writer.writeUnsignedNumber(2, this.charsetNumber);
+  let defaultFlags = ConnectionConfig.getDefaultFlags();
+  let mergedFlags = ConnectionConfig.mergeFlags(defaultFlags);
+  if(mergedFlags & Client.CLIENT_PLUGIN_AUTH != 0) {
+    writer.writeNullTerminatedString("mysql_native_password");
+  }
 };


### PR DESCRIPTION
After 
Support auth switch in change user flow https://github.com/mysqljs/mysql/pull/1730
and 
Support auth switch in change user flow https://github.com/mysqljs/mysql/commit/c144ddacb0fd7f5b65e02f227cd149a52dedfb36  

I think the driver can be considered support plugin_auth with "mysql_native_password". after these two changes, the command changeUser still does not work with Azure MySQL server since Azure MySQL server forces com_change_user packet fill Client Auth Plugin field. 

Can we turn on the flag and can you help review the change?