### PR TITLE
Fix Mariadb testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ matrix:
       env: "DOCKER_MYSQL_TYPE=mariadb DOCKER_MYSQL_VERSION=10.2"
     - node_js: *lts
       env: "DOCKER_MYSQL_TYPE=mariadb DOCKER_MYSQL_VERSION=10.3"
+    - node_js: *lts
+      env: "DOCKER_MYSQL_TYPE=mariadb DOCKER_MYSQL_VERSION=10.4"
+    - node_js: *lts
+      env: "DOCKER_MYSQL_TYPE=mariadb DOCKER_MYSQL_VERSION=10.5"
 
 dist: trusty
 addons:

--- a/test/integration/connection/test-load-data-infile.js
+++ b/test/integration/connection/test-load-data-infile.js
@@ -11,42 +11,48 @@ common.getTestConnection(function (err, connection) {
 
   common.useTestDb(connection);
 
-  connection.query([
-    'CREATE TEMPORARY TABLE ?? (',
-    '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
-    '`title` varchar(400),',
-    'PRIMARY KEY (`id`)',
-    ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
-  ].join('\n'), [table], assert.ifError);
-
-  var sql =
-    'LOAD DATA LOCAL INFILE ? INTO TABLE ?? CHARACTER SET utf8 ' +
-    'FIELDS TERMINATED BY ? ' +
-    'LINES TERMINATED BY ? ' +
-    '(id, title)';
-
-  connection.query(sql, [path, table, ',', newline], function (err, result) {
+  // only test result if server permits local infile
+  connection.query('SELECT @@local_infile', function (err, rows) {
     assert.ifError(err);
-    assert.equal(result.affectedRows, 5);
-  });
+    if (rows[0]['@@local_infile'] === 1) {
 
-  connection.query('SELECT * FROM ??', [table], function (err, rows) {
-    assert.ifError(err);
-    assert.equal(rows.length, 5);
-    assert.equal(rows[0].id, 1);
-    assert.equal(rows[0].title, 'Hello World');
-    assert.equal(rows[3].id, 4);
-    assert.equal(rows[3].title, '中文内容');
-    assert.equal(rows[4].id, 5);
-    assert.equal(rows[4].title.length, 321);
-    assert.equal(rows[4].title, 'this is a long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long string');
-  });
+      connection.query([
+        'CREATE TEMPORARY TABLE ?? (',
+        '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+        '`title` varchar(400),',
+        'PRIMARY KEY (`id`)',
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+      ].join('\n'), [table], assert.ifError);
 
-  connection.query(sql, [badPath, table, ',', newline], function (err, result) {
-    assert.ok(err);
-    assert.equal(err.code, 'ENOENT');
-    assert.equal(result.affectedRows, 0);
-  });
+      var sql =
+          'LOAD DATA LOCAL INFILE ? INTO TABLE ?? CHARACTER SET utf8 ' +
+          'FIELDS TERMINATED BY ? ' +
+          'LINES TERMINATED BY ? ' +
+          '(id, title)';
 
-  connection.end(assert.ifError);
+      connection.query(sql, [path, table, ',', newline], function (err, result) {
+        assert.ifError(err);
+        assert.equal(result.affectedRows, 5);
+      });
+
+      connection.query('SELECT * FROM ??', [table], function (err, rows) {
+        assert.ifError(err);
+        assert.equal(rows.length, 5);
+        assert.equal(rows[0].id, 1);
+        assert.equal(rows[0].title, 'Hello World');
+        assert.equal(rows[3].id, 4);
+        assert.equal(rows[3].title, '中文内容');
+        assert.equal(rows[4].id, 5);
+        assert.equal(rows[4].title.length, 321);
+        assert.equal(rows[4].title, 'this is a long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long string');
+      });
+
+      connection.query(sql, [badPath, table, ',', newline], function (err, result) {
+        assert.ok(err);
+        assert.equal(err.code, 'ENOENT');
+        assert.equal(result.affectedRows, 0);
+      });
+    }
+    connection.end(assert.ifError);
+  });
 });

--- a/test/integration/connection/test-multiple-statements-load-data-infile.js
+++ b/test/integration/connection/test-multiple-statements-load-data-infile.js
@@ -10,42 +10,49 @@ common.getTestConnection({multipleStatements: true}, function (err, connection) 
 
   common.useTestDb(connection);
 
-  connection.query([
-    'CREATE TEMPORARY TABLE ?? (',
-    '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
-    '`title` varchar(400),',
-    'PRIMARY KEY (`id`)',
-    ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
-  ].join('\n'), [table], assert.ifError);
-
-  var stmt =
-    'LOAD DATA LOCAL INFILE ? INTO TABLE ?? CHARACTER SET utf8 ' +
-    'FIELDS TERMINATED BY ? ' +
-    'LINES TERMINATED BY ? ' +
-    '(id, title)';
-
-  var sql =
-    connection.format(stmt, [path, table, ',', newline]) + ';' +
-    connection.format(stmt, [path, table, ',', newline]) + ';';
-
-  connection.query(sql, function (err, results) {
+  // only test result if server permits local infile
+  connection.query('SELECT @@local_infile', function (err, rows) {
     assert.ifError(err);
-    assert.equal(results.length, 2);
-    assert.equal(results[0].affectedRows, 5);
-    assert.equal(results[1].affectedRows, 0);
-  });
+    if (rows[0]['@@local_infile'] === 1) {
 
-  connection.query('SELECT * FROM ??', [table], function (err, rows) {
-    assert.ifError(err);
-    assert.equal(rows.length, 5);
-    assert.equal(rows[0].id, 1);
-    assert.equal(rows[0].title, 'Hello World');
-    assert.equal(rows[3].id, 4);
-    assert.equal(rows[3].title, '中文内容');
-    assert.equal(rows[4].id, 5);
-    assert.equal(rows[4].title.length, 321);
-    assert.equal(rows[4].title, 'this is a long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long string');
-  });
+      connection.query([
+        'CREATE TEMPORARY TABLE ?? (',
+        '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+        '`title` varchar(400),',
+        'PRIMARY KEY (`id`)',
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+      ].join('\n'), [table], assert.ifError);
 
-  connection.end(assert.ifError);
+      var stmt =
+          'LOAD DATA LOCAL INFILE ? INTO TABLE ?? CHARACTER SET utf8 ' +
+          'FIELDS TERMINATED BY ? ' +
+          'LINES TERMINATED BY ? ' +
+          '(id, title)';
+
+      var sql =
+          connection.format(stmt, [path, table, ',', newline]) + ';' +
+          connection.format(stmt, [path, table, ',', newline]) + ';';
+
+      connection.query(sql, function (err, results) {
+        assert.ifError(err);
+        assert.equal(results.length, 2);
+        assert.equal(results[0].affectedRows, 5);
+        assert.equal(results[1].affectedRows, 0);
+      });
+
+      connection.query('SELECT * FROM ??', [table], function (err, rows) {
+        assert.ifError(err);
+        assert.equal(rows.length, 5);
+        assert.equal(rows[0].id, 1);
+        assert.equal(rows[0].title, 'Hello World');
+        assert.equal(rows[3].id, 4);
+        assert.equal(rows[3].title, '中文内容');
+        assert.equal(rows[4].id, 5);
+        assert.equal(rows[4].title.length, 321);
+        assert.equal(rows[4].title, 'this is a long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long string');
+      });
+    }
+
+    connection.end(assert.ifError);
+  });
 });

--- a/test/integration/connection/test-statistics.js
+++ b/test/integration/connection/test-statistics.js
@@ -13,7 +13,9 @@ common.getTestConnection(function (err, connection) {
     assert.ok(data.hasOwnProperty('questions'));
     assert.ok(data.hasOwnProperty('slow_queries'));
     assert.ok(data.hasOwnProperty('opens'));
-    assert.ok(data.hasOwnProperty('flush_tables'));
+    if (!common.isMariaDB(connection)) {
+      assert.ok(data.hasOwnProperty('flush_tables'));
+    }
     assert.ok(data.hasOwnProperty('open_tables'));
     assert.ok(data.hasOwnProperty('queries_per_second_avg'));
     connection.end(assert.ifError);


### PR DESCRIPTION
MariaDB 5.5 and 10.0 version are EOL, Adding current GA version to test suite
change statistics test (mariadb doesn't have flush_tables)
change load data infile disable (MariaDB return a specific error 4166 : ER_LOAD_INFILE_CAPABILITY_DISABLED)