### PR TITLE
Update RowDataPacket.js

### DIFF
--- a/lib/protocol/packets/RowDataPacket.js
+++ b/lib/protocol/packets/RowDataPacket.js
@@ -39,7 +39,9 @@ function parse(parser, fieldPackets, typeCast, nestTables, connection) {
           : parser.parseLengthCodedString() );
     }
 
-    if (typeof nestTables === 'string' && nestTables.length) {
+    if (Array.isArray(nestTables)) {
+      this[i] = value;
+    } else if (typeof nestTables === 'string' && nestTables.length) {
       this[fieldPacket.table + nestTables + fieldPacket.name] = value;
     } else if (nestTables) {
       this[fieldPacket.table] = this[fieldPacket.table] || {};


### PR DESCRIPTION
Make it possible for getting column by its index (just like field list). This way you can implement your own unique strategy outside the module. 

Usage: 
conn.query({ sql, nestTables: [] }, function(error, results, fields) {  } );