### PR TITLE
Fixed broken link in Error handling section of README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1249,7 +1249,7 @@ object. Additionally they typically come with two extra properties:
 * `err.sqlMessage`: String, contains the message string that provides a
   textual description of the error. Only populated from [MySQL server error][].
 
-[Error]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
+[Error]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 [MySQL server error]: https://dev.mysql.com/doc/refman/5.5/en/server-error-reference.html
 
 Fatal errors are propagated to *all* pending callbacks. In the example below, a


### PR DESCRIPTION
The link Error Object was broken, so I fixed it.