### PR TITLE
Fix ECMA specification link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -229,7 +229,7 @@ issue [#501](https://github.com/mysqljs/mysql/issues/501). (Default: `false`)
 * `bigNumberStrings`: Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers
   (BIGINT and DECIMAL columns) to be always returned as JavaScript String objects (Default: `false`).
   Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String
-  objects only when they cannot be accurately represented with [JavaScript Number objects] (http://ecma262-5.com/ELS5_HTML.htm#Section_8.5)
+  objects only when they cannot be accurately represented with [JavaScript Number objects] (https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type)
   (which happens when they exceed the [-2^53, +2^53] range), otherwise they will be returned as
   Number objects. This option is ignored if `supportBigNumbers` is disabled.
 * `dateStrings`: Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather than


### PR DESCRIPTION
I changed the current link, which points to a drug addiction treatment website, to the correct specification page.