### PR TITLE
Set TCP_NODELAY flag on TCP socket (disable Nagle's algorithm).

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -429,6 +429,7 @@ Connection.prototype._handleProtocolDrain = function() {
 
 Connection.prototype._handleProtocolConnect = function() {
   this.state = 'connected';
+  this._socket.setNoDelay(true);
   this.emit('connect');
 };
 


### PR DESCRIPTION
This ensures packets are sent as soon as they're ready, lowering latency.

Other MySQL connectors/drivers used in other programming languages that I have looked at set this as a default.

A majority of HTTP clients/servers/proxies also set TCP_NODELAY as a default (e.g. curl, Nginx, HA_Proxy). 