### PR TITLE
Use WHATWG URL parsing, if available, instead of url.parse

### DIFF
--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -187,11 +187,7 @@ ConnectionConfig.parseUrl = function(url) {
 
   if (typeof url.username == 'string') {
     options.user     = url.username;
-    try {
-      options.password = decodeURIComponent(url.password);
-    } catch (e) {
-      options.password = url.password;
-    }
+    options.password = decodeUriComponent(url.password);
   } else if (url.auth) {
     var auth = url.auth.split(':');
     options.user     = auth.shift();
@@ -224,3 +220,13 @@ ConnectionConfig.parseUrl = function(url) {
 
   return options;
 };
+
+function decodeUriComponent(str) {
+  return str.replace(/\%([a-f0-9]{2})/ig, function (_, hex) {
+    try {
+      return String.fromCharCode(parseInt(hex, 16));
+    } catch (e) {
+      return _;
+    }
+  });
+}

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -177,7 +177,7 @@ ConnectionConfig.parseFlagList = function parseFlagList(flagList) {
 };
 
 ConnectionConfig.parseUrl = function(url) {
-  url = urlParse(url, true);
+  url = (typeof URL == 'function' && typeof URL.prototype == 'object' ? new URL(url) : urlParse(url, true));
 
   var options = {
     host     : url.hostname,
@@ -185,13 +185,28 @@ ConnectionConfig.parseUrl = function(url) {
     database : url.pathname.substr(1)
   };
 
-  if (url.auth) {
+  if (typeof url.username == 'string') {
+    options.user     = url.username;
+    options.password = url.password;
+  } else if (url.auth) {
     var auth = url.auth.split(':');
     options.user     = auth.shift();
     options.password = auth.join(':');
   }
 
-  if (url.query) {
+  if (url.searchParams) {
+    for (var key in url.searchParams) {
+      var value = url.searchParams[key];
+
+      try {
+        // Try to parse this as a JSON expression first
+        options[key] = JSON.parse(value);
+      } catch (err) {
+        // Otherwise assume it is a plain string
+        options[key] = value;
+      }
+    }
+  } else if (url.query) {
     for (var key in url.query) {
       var value = url.query[key];
 

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -187,7 +187,11 @@ ConnectionConfig.parseUrl = function(url) {
 
   if (typeof url.username == 'string') {
     options.user     = url.username;
-    options.password = url.password;
+    try {
+      options.password = decodeURIComponent(url.password);
+    } catch (e) {
+      options.password = url.password;
+    }
   } else if (url.auth) {
     var auth = url.auth.split(':');
     options.user     = auth.shift();

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -195,9 +195,7 @@ ConnectionConfig.parseUrl = function(url) {
   }
 
   if (url.searchParams) {
-    for (var key in url.searchParams) {
-      var value = url.searchParams[key];
-
+    url.searchParams.forEach(function (value, key) {
       try {
         // Try to parse this as a JSON expression first
         options[key] = JSON.parse(value);
@@ -205,7 +203,7 @@ ConnectionConfig.parseUrl = function(url) {
         // Otherwise assume it is a plain string
         options[key] = value;
       }
-    }
+    });
   } else if (url.query) {
     for (var key in url.query) {
       var value = url.query[key];

--- a/test/unit/test-ConnectionConfig.js
+++ b/test/unit/test-ConnectionConfig.js
@@ -3,7 +3,6 @@ var Crypto           = require('crypto');
 var test             = require('utest');
 var assert           = require('assert');
 var ConnectionConfig = common.ConnectionConfig;
-var usesWhatwgUrl    = (typeof URL == 'function' && typeof URL.prototype == 'object');
 
 test('ConnectionConfig#Constructor', {
   'takes user,pw,host,port,db from url string': function() {
@@ -24,7 +23,7 @@ test('ConnectionConfig#Constructor', {
     assert.equal(config.host, 'myhost');
     assert.equal(config.port, 3333);
     assert.equal(config.user, 'myuser');
-    assert.equal(config.password, usesWhatwgUrl ? 'my%3Apass' : 'my:pass');
+    assert.equal(config.password, 'my:pass');
     assert.equal(config.database, 'mydb');
   },
 

--- a/test/unit/test-ConnectionConfig.js
+++ b/test/unit/test-ConnectionConfig.js
@@ -3,6 +3,7 @@ var Crypto           = require('crypto');
 var test             = require('utest');
 var assert           = require('assert');
 var ConnectionConfig = common.ConnectionConfig;
+var usesWhatwgUrl    = (typeof URL == 'function' && typeof URL.prototype == 'object');
 
 test('ConnectionConfig#Constructor', {
   'takes user,pw,host,port,db from url string': function() {
@@ -23,7 +24,7 @@ test('ConnectionConfig#Constructor', {
     assert.equal(config.host, 'myhost');
     assert.equal(config.port, 3333);
     assert.equal(config.user, 'myuser');
-    assert.equal(config.password, 'my:pass');
+    assert.equal(config.password, usesWhatwgUrl ? 'my%3Apass' : 'my:pass');
     assert.equal(config.database, 'mydb');
   },
 


### PR DESCRIPTION
The strategy:

1. Check if `URL` is a function
2. Check if `URL.prototype` is an object

If the checks are true, use `new URL` instead of `url.parse`.

The only 2 changes I know of, are:

1. `URL` has `username` and `password` already parsed, no need to check for `auth`
2. `URL` has `searchParams` instead of `query`

Closes #2563