### PR TITLE
Allow connectionString and options

### DIFF
--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -9,6 +9,10 @@ function ConnectionConfig(options) {
     options = ConnectionConfig.parseUrl(options);
   }
 
+  if (typeof options.connectionString === 'string') {
+    options = { ...ConnectionConfig.parseUrl(options.connectionString), ...options };
+  }
+
   this.host               = options.host || 'localhost';
   this.port               = options.port || 3306;
   this.localAddress       = options.localAddress;


### PR DESCRIPTION
Currently there is no way for the user to specify (that I could find).
for example `typeCast` if we are using a connection string. This makes it possible to specify a `connectionString` option and then override individual options if needed